### PR TITLE
documentation Systems

### DIFF
--- a/docs/src/lib/systems.md
+++ b/docs/src/lib/systems.md
@@ -54,8 +54,8 @@ NonDeterministicInput
 ```
 
 The inputs are closely related to a [`DiscreteSystem`](@ref) in the sense that
-for each discrete time step the inputs may change. The `InputState` type allows
-an iteration through the inputs over time.
+for each discrete time step the input set may change. The `InputState` type
+allows an iteration through the inputs over time.
 
 ```@docs
 InputState
@@ -64,7 +64,8 @@ InputState
 ### Constant nondeterministic inputs
 
 Constant nondeterministic inputs are chosen from a set of values that does not
-change over time.
+change over time. Note that, while the set is constant, the inputs themselves
+vary over time.
 
 ```@docs
 ConstantNonDeterministicInput

--- a/src/Systems/Systems.jl
+++ b/src/Systems/Systems.jl
@@ -29,9 +29,12 @@ abstract type NonDeterministicInput end
 
 
 """
+    InputState
+
 Type that represents the state of a `NonDeterministicInput`.
 
 ### Fields
+
 - `set`   -- current set
 - `index` -- index in the iteration
 """
@@ -48,6 +51,8 @@ InputState(set::LazySet) = InputState(set, 1)
 
 
 """
+    ConstantNonDeterministicInput <: NonDeterministicInput
+
 Type that represents a constant nondeterministic input.
 
 The iteration over this set is such that its `state` is a tuple
@@ -59,14 +64,18 @@ input state is always constantly 1.
 ### Fields
 
 - `U` -- `LazySet`
+
+### Examples
+
+`ConstantNonDeterministicInput(U::LazySet)` -- default constructor
 """
 struct ConstantNonDeterministicInput <: NonDeterministicInput
     # input
     U::LazySet
 
+    # default constructor
     ConstantNonDeterministicInput(U::LazySet) = new(U)
 end
-ConstantNonDeterministicInput() = ConstantNonDeterministicInput(VoidSet(0))
 
 
 Base.start(NDInput::ConstantNonDeterministicInput) = InputState(NDInput.U)
@@ -82,6 +91,8 @@ end
 
 
 """
+    TimeVaryingNonDeterministicInput <: NonDeterministicInput
+
 Type that represents a time-varying nondeterministic input.
 
 The iteration over this set is such that its `state` is a tuple
@@ -94,18 +105,26 @@ index in the input array.
 ### Fields
 
 - `U` -- array containing `LazySet`s
+
+### Examples
+
+`TimeVaryingNonDeterministicInput(U::Vector{<:LazySet})` -- constructor from a
+vector of sets
 """
 struct TimeVaryingNonDeterministicInput <: NonDeterministicInput
     # input sequence
     U::Vector{<:LazySet}
 
+    # default constructor
     TimeVaryingNonDeterministicInput(U::Vector{<:LazySet}) = new(U)
 end
 
 
 Base.start(NDInput::TimeVaryingNonDeterministicInput) = InputState(NDInput.U[1])
-Base.next(NDInput::TimeVaryingNonDeterministicInput, state) = InputState(NDInput.U[state.index+1], state.index+1)
-Base.done(NDInput::TimeVaryingNonDeterministicInput, state) = state.index > length(NDInput.U)
+Base.next(NDInput::TimeVaryingNonDeterministicInput, state) =
+    InputState(NDInput.U[state.index+1], state.index+1)
+Base.done(NDInput::TimeVaryingNonDeterministicInput, state) =
+    state.index > length(NDInput.U)
 Base.eltype(::Type{TimeVaryingNonDeterministicInput}) = Type{InputState}
 Base.length(NDInput::TimeVaryingNonDeterministicInput) = length(NDInput.U)
 
@@ -122,8 +141,10 @@ abstract type AbstractSystem end
 
 
 """
-Type that represents a system of continuous-time affine ODEs with nondeterministic
-inputs,
+    ContinuousSystem <: AbstractSystem
+
+Type that represents a system of continuous-time affine ODEs with
+nondeterministic inputs,
 
 ``x'(t) = Ax(t) + u(t)``,
 
@@ -131,15 +152,32 @@ where:
 
 - ``A`` is a square matrix
 - ``x(0) ∈ \\mathcal{X}_0`` and ``\\mathcal{X}_0`` is a convex set
-- ``u(t) ∈ \\mathcal{U}(t)``, where ``\\mathcal{U}(\\cdot)`` is a piecewise-constant
-  set-valued function, i.e. we consider that it can be approximated by a possibly
-  time-varying discrete sequence ``\\{\\mathcal{U}_k \\}_k``
+- ``u(t) ∈ \\mathcal{U}(t)``, where ``\\mathcal{U}(\\cdot)`` is a
+  piecewise-constant set-valued function, i.e. we consider that it can be
+  approximated by a possibly time-varying discrete sequence
+  ``\\{\\mathcal{U}_k \\}_k``
 
 ### Fields
 
 - `A`  -- square matrix
 - `X0` -- set of initial states
 - `U`  -- nondeterministic inputs
+
+### Examples
+
+- `ContinuousSystem(A::AbstractMatrix{Float64},
+                    X0::LazySet,
+                    U::NonDeterministicInput)` -- default constructor
+- `ContinuousSystem(A::AbstractMatrix{Float64},
+                    X0::LazySet)` -- constructor with no inputs
+- `ContinuousSystem(A::AbstractMatrix{Float64},
+                    X0::LazySet,
+                    U::LazySet)` -- constructor that creates a
+  `ConstantNonDeterministicInput`
+- `ContinuousSystem(A::AbstractMatrix{Float64},
+                    X0::LazySet,
+                    U::Vector{<:LazySet})` -- constructor that creates a
+  `TimeVaryingNonDeterministicInput`
 """
 struct ContinuousSystem <: AbstractSystem
     # system's matrix
@@ -155,16 +193,21 @@ struct ContinuousSystem <: AbstractSystem
                      U::NonDeterministicInput) =
         new(A, X0, U)
 end
+# constructor with no inputs
 ContinuousSystem(A::AbstractMatrix{Float64},
                  X0::LazySet) =
     ContinuousSystem(A, X0, ConstantNonDeterministicInput(VoidSet(size(A, 1))))
+
+# constructor that creates a ConstantNonDeterministicInput
 ContinuousSystem(A::AbstractMatrix{Float64},
                  X0::LazySet,
                  U::LazySet) =
     ContinuousSystem(A, X0, ConstantNonDeterministicInput(U))
+
+# constructor that creates a TimeVaryingNonDeterministicInput
 ContinuousSystem(A::AbstractMatrix{Float64},
                  X0::LazySet,
-                 U::Array{<:LazySet, 1}) =
+                 U::Vector{<:LazySet}) =
     ContinuousSystem(A, X0, TimeVaryingNonDeterministicInput(U))
 
 
@@ -176,6 +219,10 @@ Dimension of a continuous system.
 ### Input
 
 - `S` -- continuous system
+
+### Output
+
+The dimension of the system.
 """
 function dim(S::ContinuousSystem)
     return size(S.A, 1)
@@ -183,7 +230,10 @@ end
 
 
 """
-Type that represents a system of discrete-time affine ODEs with nondeterministic inputs,
+    DiscreteSystem <: AbstractSystem
+
+Type that represents a system of discrete-time affine ODEs with nondeterministic
+inputs,
 
 ``x_{k+1} = A x_{k} + u_{k}``
 
@@ -192,14 +242,35 @@ where:
 - ``A`` is a square matrix
 - ``x(0) ∈ \\mathcal{X}_0`` and ``\\mathcal{X}_0`` is a convex set
 - ``u_{k} ∈ \\mathcal{U}_{k}``, where ``\\{\\mathcal{U}_{k}\\}_k`` is a
-  set-valued sequence defined over ``[0, δ], ..., [(N-1)δ, N δ]`` for some ``δ>0``
+  set-valued sequence defined over ``[0, δ], ..., [(N-1)δ, N δ]`` for some
+  ``δ>0``
 
 ### Fields
 
-- `A`  -- square matrix
+- `A`  -- square matrix, possibly of type `SparseMatrixExp`
 - `X0` -- set of initial states
 - `U`  -- nondeterministic inputs
 - `δ`  -- discretization step
+
+### Examples
+
+- `DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},
+                   X0::LazySet,
+                   δ::Float64,
+                   U::NonDeterministicInput)` -- default constructor
+- `DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},
+               X0::LazySet,
+               δ::Float64)` -- constructor with no inputs
+- `DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},
+               X0::LazySet,
+               δ::Float64,
+               U::LazySet)` -- constructor that creates a
+  `ConstantNonDeterministicInput`
+- `DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},
+               X0::LazySet,
+               δ::Float64,
+               U::Vector{<:LazySet})` -- constructor that creates a
+  `TimeVaryingNonDeterministicInput`
 """
 struct DiscreteSystem <: AbstractSystem
     # system's matrix
@@ -211,31 +282,34 @@ struct DiscreteSystem <: AbstractSystem
     # discretization step
     δ::Float64
 
-    # default constructor with some domain checks
+    # default constructor that checks for nonnegative δ
     DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},
                    X0::LazySet,
                    δ::Float64,
                    U::NonDeterministicInput) =
         (δ < 0.
-            ? throw(DomainError())
-            : new(A, X0, U, δ))
+         ? throw(DomainError())
+         : new(A, X0, U, δ))
 end
 
+# constructor with no inputs
 DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},
                X0::LazySet,
                δ::Float64) =
     DiscreteSystem(A, X0, δ, ConstantNonDeterministicInput(VoidSet(size(A, 1))))
 
+# constructor that creates a ConstantNonDeterministicInput
 DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},
                X0::LazySet,
                δ::Float64,
                U::LazySet) =
     DiscreteSystem(A, X0, δ, ConstantNonDeterministicInput(U))
 
+# constructor that creates a TimeVaryingNonDeterministicInput
 DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},
                X0::LazySet,
                δ::Float64,
-               U::Array{<:LazySet, 1}) =
+               U::Vector{<:LazySet}) =
     DiscreteSystem(A, X0, δ, TimeVaryingNonDeterministicInput(U))
 
 
@@ -247,6 +321,10 @@ Dimension of a discrete system.
 ### Input
 
 - `S` -- discrete system
+
+### Output
+
+The dimension of the system.
 """
 function dim(S::DiscreteSystem)
     return size(S.A, 1)

--- a/test/Systems/unit_NonDeterministicInput.jl
+++ b/test/Systems/unit_NonDeterministicInput.jl
@@ -1,9 +1,5 @@
 import Reachability.Systems: ConstantNonDeterministicInput, TimeVaryingNonDeterministicInput
 
-# Testing null constant input
-state = start(ConstantNonDeterministicInput())
-@test isa(state.set, VoidSet)
-
 # Testing constant non-deterministic input
 c = zeros(4); r = 0.1
 U = BallInf(c, r)


### PR DESCRIPTION
- revised documentation for `Systems` according to new standards
- removed constructor for empty `ConstantNonDeterministicInput`