### PR TITLE
[WIP] adapt to LazySets changes

### DIFF
--- a/src/Properties/check_explicit_block.jl
+++ b/src/Properties/check_explicit_block.jl
@@ -48,11 +48,11 @@ function check_explicit_block!(ϕ::SparseMatrixCSC{Float64, Int64},
     Whatk = overapproximate(G0(bi) * inputs)
     ϕpowerk = copy(ϕ)
 
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
 
     k = 2
     @inbounds while true
-        Xhatk_bi = voidSet2
+        Xhatk_bi = dummy_set
         for bj in 1:b
             if findfirst(F(bi, bj)) != 0
                 Xhatk_bi = Xhatk_bi + F(bi, bj) * Xhat0[bj]
@@ -89,13 +89,13 @@ function check_explicit_block!(ϕ::SparseMatrixCSC{Float64, Int64},
 
     @inline F(bi::Int64, bj::Int64) = ϕpowerk[(2*bi-1):(2*bi), (2*bj-1):(2*bj)]
 
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
 
     ϕpowerk = copy(ϕ)
 
     k = 2
     @inbounds while true
-        Xhatk_bi = voidSet2
+        Xhatk_bi = dummy_set
         for bj in 1:b
             if findfirst(F(bi, bj)) != 0
                 Xhatk_bi = Xhatk_bi + F(bi, bj) * Xhat0[bj]

--- a/src/Properties/check_explicit_blocks.jl
+++ b/src/Properties/check_explicit_blocks.jl
@@ -46,9 +46,9 @@ function check_explicit_blocks!(ϕ::SparseMatrixCSC{Float64, Int64},
 
     Xhatk = Vector{LazySet}(b)
     Whatk = Vector{LazySet}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     inputs = next_set(U)
@@ -60,7 +60,7 @@ function check_explicit_blocks!(ϕ::SparseMatrixCSC{Float64, Int64},
     k = 2
     @inbounds while true
         for bi in blocks
-            Xhatk_bi = voidSet2
+            Xhatk_bi = dummy_set
             for bj in 1:b
                 if findfirst(F(bi, bj)) != 0
                     Xhatk_bi = Xhatk_bi + F(bi, bj) * Xhat0[bj]
@@ -102,9 +102,9 @@ function check_explicit_blocks!(ϕ::SparseMatrixCSC{Float64, Int64},
     @inline F(bi::Int64, bj::Int64) = ϕpowerk[(2*bi-1):(2*bi), (2*bj-1):(2*bj)]
 
     Xhatk = Vector{LazySet}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     ϕpowerk = copy(ϕ)
@@ -112,7 +112,7 @@ function check_explicit_blocks!(ϕ::SparseMatrixCSC{Float64, Int64},
     k = 2
     @inbounds while true
         for bi in blocks
-            Xhatk_bi = voidSet2
+            Xhatk_bi = dummy_set
             for bj in 1:b
                 if findfirst(F(bi, bj)) != 0
                     Xhatk_bi = Xhatk_bi + F(bi, bj) * Xhat0[bj]
@@ -156,9 +156,9 @@ function check_explicit_blocks!(ϕ::AbstractMatrix{Float64},
 
     Xhatk = Vector{LazySet}(b)
     Whatk = Vector{LazySet}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     inputs = next_set(U)
@@ -211,9 +211,9 @@ function check_explicit_blocks!(ϕ::AbstractMatrix{Float64},
     @inline F(bi::Int64, bj::Int64) = ϕpowerk[(2*bi-1):(2*bi), (2*bj-1):(2*bj)]
 
     Xhatk = Vector{LazySet}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     ϕpowerk = copy(ϕ)
@@ -256,9 +256,9 @@ function check_explicit_blocks!(ϕ::SparseMatrixExp{Float64},
     end
 
     Xhatk = Vector{LazySet}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     ϕpowerk = SparseMatrixExp(ϕ.M)
@@ -307,9 +307,9 @@ function check_explicit_blocks!(ϕ::SparseMatrixExp{Float64},
 
     Xhatk = Vector{LazySet}(b)
     Whatk = Vector{LazySet}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     inputs = next_set(U)

--- a/src/ReachSets/discretize.jl
+++ b/src/ReachSets/discretize.jl
@@ -143,7 +143,7 @@ function discr_no_bloat(cont_sys::ContinuousSystem,
 
     # early return for homogeneous systems
     inputs = next_set(cont_sys.U, 1)
-    if isa(inputs, VoidSet) && length(cont_sys.U) == 1
+    if isa(inputs, ZeroSet) && length(cont_sys.U) == 1
             Ω0 = cont_sys.X0
             return DiscreteSystem(ϕ, Ω0, δ)
     end
@@ -225,7 +225,7 @@ function discr_bloat_interpolation(cont_sys::ContinuousSystem,
 
     # early return for homogeneous systems
     inputs = next_set(cont_sys.U, 1)
-    if isa(inputs, VoidSet) && length(cont_sys.U) == 1
+    if isa(inputs, ZeroSet) && length(cont_sys.U) == 1
             Ω0 = CH(cont_sys.X0, ϕ * cont_sys.X0)
             return DiscreteSystem(ϕ, Ω0, δ)
     end
@@ -243,10 +243,8 @@ function discr_bloat_interpolation(cont_sys::ContinuousSystem,
         Phi2Aabs = P[1:n, (2*n+1):3*n]
     end
 
-    if isa(inputs, VoidSet)
-        if approx_model == "forward"
-            Ω0 = CH(cont_sys.X0, ϕ * cont_sys.X0 + δ * inputs)
-        elseif approx_model == "backward"
+    if isa(inputs, ZeroSet)
+        if approx_model == "forward" || approx_model == "backward"
             Ω0 = CH(cont_sys.X0, ϕ * cont_sys.X0 + δ * inputs)
         end
     else

--- a/src/ReachSets/project_reach.jl
+++ b/src/ReachSets/project_reach.jl
@@ -78,7 +78,8 @@ function project_reach(plot_vars::Vector{Int64}, n::Int64,
         radius = δ/2.0
         t = radius
         @inbounds for i in 1:N
-            RsetsProj[i] = overapproximate(projection_matrix * (Rsets[i] * BallInf([t], radius)), ɛ)
+            RsetsProj[i] = overapproximate(projection_matrix *
+                CartesianProduct(Rsets[i], BallInf([t], radius)), ɛ)
             t = t + δ
         end
     else
@@ -150,7 +151,8 @@ function project_reach(plot_vars::Vector{Int64}, n::Int64, δ::Float64,
         radius = δ/2.0
         t = radius
         @inbounds for i in 1:N
-            RsetsProj[i] = overapproximate(projection_matrix * (Rsets[i] * BallInf([t], radius)), ɛ)
+            RsetsProj[i] = overapproximate(projection_matrix * 
+                CartesianProduct(Rsets[i], BallInf([t], radius)), ɛ)
             t = t + δ
         end
     else

--- a/src/ReachSets/reach_explicit_block.jl
+++ b/src/ReachSets/reach_explicit_block.jl
@@ -50,11 +50,11 @@ function reach_explicit_block!(ϕ::SparseMatrixCSC{Float64, Int64},
     Whatk_bi::HPolygon = overapproximate(G0(bi) * inputs)
     ϕpowerk = copy(ϕ)
 
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
 
     k = 2
     @inbounds while true
-        Xhatk_bi = voidSet2
+        Xhatk_bi = dummy_set
         for bj in 1:b
             if findfirst(F(bi, bj)) != 0
                 Xhatk_bi = Xhatk_bi + F(bi, bj) * Xhat0[bj]
@@ -94,11 +94,11 @@ function reach_explicit_block!(ϕ::SparseMatrixCSC{Float64, Int64},
 
     ϕpowerk = copy(ϕ)
 
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
 
     k = 2
     @inbounds while true
-        Xhatk_bi = voidSet2
+        Xhatk_bi = dummy_set
         for bj in 1:b
             if findfirst(F(bi, bj)) != 0
                 Xhatk_bi = Xhatk_bi + F(bi, bj) * Xhat0[bj]
@@ -216,13 +216,13 @@ function reach_explicit_block!(ϕ::SparseMatrixExp{Float64},
         return
     end
 
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     ϕpowerk = SparseMatrixExp(ϕ.M)
 
     k = 2
     @inbounds while true
         ϕpowerk_πbi = get_rows(ϕpowerk, (2*bi-1):(2*bi))
-        Xhatk_bi = voidSet2
+        Xhatk_bi = dummy_set
         for bj in 1:b
             πbi = ϕpowerk_πbi[:, (2*bj-1):(2*bj)]
             if findfirst(πbi) != 0
@@ -258,7 +258,7 @@ function reach_explicit_block!(ϕ::SparseMatrixExp{Float64},
         return
     end
 
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     inputs = next_set(U)
     Whatk_bi::HPolygon = overapproximate(sparse(1:2, (2*bi-1):(2*bi), [1., 1.], 2, n) * inputs)
     ϕpowerk = SparseMatrixExp(ϕ.M)
@@ -266,7 +266,7 @@ function reach_explicit_block!(ϕ::SparseMatrixExp{Float64},
     k = 2
     @inbounds while true
         ϕpowerk_πbi = get_rows(ϕpowerk, (2*bi-1):(2*bi))
-        Xhatk_bi = voidSet2
+        Xhatk_bi = dummy_set
         for bj in 1:b
             πbi = ϕpowerk_πbi[:, (2*bj-1):(2*bj)]
             if findfirst(πbi) != 0

--- a/src/ReachSets/reach_explicit_blocks.jl
+++ b/src/ReachSets/reach_explicit_blocks.jl
@@ -21,7 +21,7 @@ INPUT:
 OUTPUT:
 
 Array of the cartesian product of two-dimensional sets (HPolygons) for the
-given block indices, and VoidSet's for the rest of them. It is obtained by
+given block indices, and ZeroSet's for the rest of them. It is obtained by
 reachability computation of a discrete affine system with undeterministic
 inputs, which can be either constant or time-varying.
 =#
@@ -49,9 +49,9 @@ function reach_explicit_blocks!(ϕ::SparseMatrixCSC{Float64, Int64},
 
     Xhatk = Vector{LazySet}(b)
     Whatk = Vector{HPolygon}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     inputs = next_set(U)
@@ -63,7 +63,7 @@ function reach_explicit_blocks!(ϕ::SparseMatrixCSC{Float64, Int64},
     k = 2
     @inbounds while true
         for bi in blocks
-            Xhatk_bi = voidSet2
+            Xhatk_bi = dummy_set
             for bj in 1:b
                 if findfirst(F(bi, bj)) != 0
                     Xhatk_bi = Xhatk_bi + F(bi, bj) * Xhat0[bj]
@@ -106,9 +106,9 @@ function reach_explicit_blocks!(ϕ::SparseMatrixCSC{Float64, Int64},
     @inline F(bi::Int64, bj::Int64) = ϕpowerk[(2*bi-1):(2*bi), (2*bj-1):(2*bj)]
 
     Xhatk = Vector{LazySet}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     ϕpowerk = copy(ϕ)
@@ -116,7 +116,7 @@ function reach_explicit_blocks!(ϕ::SparseMatrixCSC{Float64, Int64},
     k = 2
     @inbounds while true
         for bi in blocks
-            Xhatk_bi = voidSet2
+            Xhatk_bi = dummy_set
             for bj in 1:b
                 if findfirst(F(bi, bj)) != 0
                     Xhatk_bi = Xhatk_bi + F(bi, bj) * Xhat0[bj]
@@ -160,9 +160,9 @@ function reach_explicit_blocks!(ϕ::AbstractMatrix{Float64},
 
     Xhatk = Vector{LazySet}(b)
     Whatk = Vector{HPolygon}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     inputs = next_set(U)
@@ -216,9 +216,9 @@ function reach_explicit_blocks!(ϕ::AbstractMatrix{Float64},
     @inline F(bi::Int64, bj::Int64) = ϕpowerk[(2*bi-1):(2*bi), (2*bj-1):(2*bj)]
 
     Xhatk = Vector{LazySet}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     ϕpowerk = copy(ϕ)
@@ -262,9 +262,9 @@ function reach_explicit_blocks!(ϕ::SparseMatrixExp{Float64},
     end
 
     Xhatk = Vector{LazySet}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     ϕpowerk = SparseMatrixExp(ϕ.M)
@@ -273,7 +273,7 @@ function reach_explicit_blocks!(ϕ::SparseMatrixExp{Float64},
     @inbounds while true
         for bi in blocks
             ϕpowerk_πbi = get_rows(ϕpowerk, (2*bi-1):(2*bi))
-            Xhatk_bi = voidSet2
+            Xhatk_bi = dummy_set
             for bj in 1:b
                 πbi = ϕpowerk_πbi[:, (2*bj-1):(2*bj)]
                 if findfirst(πbi) != 0
@@ -316,9 +316,9 @@ function reach_explicit_blocks!(ϕ::SparseMatrixExp{Float64},
 
     Xhatk = Vector{LazySet}(b)
     Whatk = Vector{HPolygon}(b)
-    voidSet2 = VoidSet(2)
+    dummy_set = ZeroSet(2)
     @inbounds for bi in 1:b
-         Xhatk[bi] = voidSet2
+         Xhatk[bi] = dummy_set
     end
 
     inputs = next_set(U)
@@ -331,7 +331,7 @@ function reach_explicit_blocks!(ϕ::SparseMatrixExp{Float64},
     @inbounds while true
         for bi in blocks
             ϕpowerk_πbi = get_rows(ϕpowerk, (2*bi-1):(2*bi))
-            Xhatk_bi = voidSet2
+            Xhatk_bi = dummy_set
             for bj in 1:b
                 πbi = ϕpowerk_πbi[:, (2*bj-1):(2*bj)]
                 if findfirst(πbi) != 0

--- a/src/Systems/Systems.jl
+++ b/src/Systems/Systems.jl
@@ -221,7 +221,7 @@ end
 # constructor with no inputs
 ContinuousSystem(A::AbstractMatrix{Float64},
                  X0::LazySet) =
-    ContinuousSystem(A, X0, ConstantNonDeterministicInput(VoidSet(size(A, 1))))
+    ContinuousSystem(A, X0, ConstantNonDeterministicInput(ZeroSet(size(A, 1))))
 
 # constructor that creates a ConstantNonDeterministicInput
 ContinuousSystem(A::AbstractMatrix{Float64},
@@ -321,7 +321,7 @@ end
 DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},
                X0::LazySet,
                δ::Float64) =
-    DiscreteSystem(A, X0, δ, ConstantNonDeterministicInput(VoidSet(size(A, 1))))
+    DiscreteSystem(A, X0, δ, ConstantNonDeterministicInput(ZeroSet(size(A, 1))))
 
 # constructor that creates a ConstantNonDeterministicInput
 DiscreteSystem(A::Union{AbstractMatrix{Float64}, SparseMatrixExp{Float64}},

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -108,11 +108,11 @@ julia> dim(Xext)
 ```
 """
 function add_dimension(X::LazySet)::LazySet
-    return X * Singleton([0])
+    return X * ZeroSet()
 end
 
-function add_dimension(X::VoidSet)::VoidSet
-    return VoidSet(dim(X)+1)
+function add_dimension(X::ZeroSet)::ZeroSet
+    return ZeroSet(dim(X)+1)
 end
 
 """

--- a/test/ReachSets/unit_discretization.jl
+++ b/test/ReachSets/unit_discretization.jl
@@ -1,7 +1,7 @@
 import Reachability.ReachSets.discretize
 
 # ===================================================================
-# Discretization of a continuous-time system without input (VoidSet)
+# Discretization of a continuous-time system without input (ZeroSet)
 # ===================================================================
 A = sparse([1, 1, 2, 3, 4], [1, 2, 2, 4, 3], [1., 2., 3., 4., 5.], 4, 4)
 X0 = BallInf(zeros(4), 0.1)
@@ -12,7 +12,7 @@ cont_sys_homog = ContinuousSystem(A, X0)
 discr_sys_homog = discretize(cont_sys_homog, δ, approx_model="nobloating", pade_expm=false)
 @test length(discr_sys_homog.U) == 1
 inputs = next_set(discr_sys_homog.U)
-@test isa(inputs, VoidSet) && dim(inputs) == 4
+@test isa(inputs, ZeroSet) && dim(inputs) == 4
 
 # no bloating, use Pade approximation
 discr_sys_homog = discretize(cont_sys_homog, δ, approx_model="nobloating", pade_expm=true)

--- a/test/Systems/unit_System.jl
+++ b/test/Systems/unit_System.jl
@@ -8,7 +8,7 @@ cont_sys_homog = ContinuousSystem(A, X0)
 # Check if the input is constant
 @test isa(cont_sys_homog.U, Systems.ConstantNonDeterministicInput)
 # Check if the input is empty
-@test isa(next_set(cont_sys_homog.U), VoidSet)
+@test isa(next_set(cont_sys_homog.U), ZeroSet)
 # Check data fields
 @test cont_sys_homog.A == A
 @test cont_sys_homog.X0.center == zeros(4) && cont_sys_homog.X0.radius == 0.1
@@ -55,7 +55,7 @@ discr_sys_homog = DiscreteSystem(A, X0, δ)
 # Check if the input is constant
 @test isa(discr_sys_homog.U, Systems.ConstantNonDeterministicInput)
 # Check if the input is empty
-@test isa(next_set(discr_sys_homog.U), VoidSet)
+@test isa(next_set(discr_sys_homog.U), ZeroSet)
 # Check data fields
 @test discr_sys_homog.A == A
 @test discr_sys_homog.X0.center == zeros(4) && discr_sys_homog.X0.radius == 0.1


### PR DESCRIPTION
I replaced all `VoidSet`s by `ZeroSet`s. This is not totally correct inside the `reach*`/`check*` functions because now for empty matrix block rows we return the zero set. But maybe this is a corner case that does not make sense anyway...

@mforets: [This line](https://github.com/JuliaReach/Reachability.jl/blob/master/src/ReachSets/project_reach.jl#L81) is making trouble in the new version. The reason is that previously we did not overload `*` for `CartesianProductArray` and hence a new `CartesianProduct` object was created (not nice, but it worked). Now we try to add the `BallInf` to the array, but it has type `HPolygon[]`, so we get a type error.

I see the following ways to solve:
* Make the `BallInf` here an `HPolygon`.
Cons: counters the plan to generalize the types (#24); not that efficient to evaluate (but projection is usually not our bottleneck)
* Generalize the array type to `LazySet`.
* Create a new array here.
* Create a new `CartesianProduct` (no `Array` here).
This would be the old behavior.

What do you think?