### PR TITLE
[WIP #75] Merge w/ and w/o inputs

### DIFF
--- a/src/Properties/check_property.jl
+++ b/src/Properties/check_property.jl
@@ -92,20 +92,19 @@ function check_property(S::AbstractSystem,
     end
     push!(args, Xhat0)
 
-    if !assume_homogeneous
-        push!(args, S.U)
+    # inputs
+    push!(args, assume_homogeneous ? nothing : S.U)
 
-        # overapproximation function (with or without iterative refinement)
-        if haskey(kwargs_dict, :block_types_iter)
-            block_types_iter = block_to_set_map(kwargs_dict[:block_types_iter])
-            push!(args, (i, x) -> block_types_iter[i] == HPolygon ?
-                                  overapproximate(x, HPolygon, ε_iter) :
-                                  overapproximate(x, block_types_iter[i]))
-        elseif ε_iter < Inf
-            push!(args, (i, x) -> overapproximate(x, set_type_iter, ε_iter))
-        else
-            push!(args, (i, x) -> overapproximate(x, set_type_iter))
-        end
+    # overapproximation function (with or without iterative refinement)
+    if haskey(kwargs_dict, :block_types_iter)
+        block_types_iter = block_to_set_map(kwargs_dict[:block_types_iter])
+        push!(args, (i, x) -> block_types_iter[i] == HPolygon ?
+                              overapproximate(x, HPolygon, ε_iter) :
+                              overapproximate(x, block_types_iter[i]))
+    elseif ε_iter < Inf
+        push!(args, (i, x) -> overapproximate(x, set_type_iter, ε_iter))
+    else
+        push!(args, (i, x) -> overapproximate(x, set_type_iter))
     end
 
     # ambient dimension

--- a/src/ReachSets/reach.jl
+++ b/src/ReachSets/reach.jl
@@ -95,9 +95,8 @@ function reach(S::AbstractSystem,
     end
     push!(args, Xhat0)
 
-    if !assume_homogeneous
-        push!(args, S.U)
-    end
+    # inputs
+    push!(args, assume_homogeneous ? nothing : S.U)
 
     # overapproximation function (with or without iterative refinement)
     if haskey(kwargs_dict, :block_types_iter)

--- a/src/ReachSets/reach_blocks.jl
+++ b/src/ReachSets/reach_blocks.jl
@@ -36,10 +36,10 @@ nondeterministic inputs.
     ϕpowerk_πbi[:, bj]
 @inline block(ϕpowerk_πbi::SparseMatrixCSC, bj::Int) = ϕpowerk_πbi[:, [bj]]
 
-# sparse, with input
+# sparse
 function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
                                 Xhat0::Vector{<:LazySet{NUM}},
-                                U::ConstantNonDeterministicInput,
+                                U::Union{ConstantNonDeterministicInput, Void},
                                 overapproximate::Function,
                                 n::Int,
                                 N::Int,
@@ -54,14 +54,16 @@ function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
 
     b = length(blocks)
     Xhatk = Vector{LazySet{NUM}}(b)
-    Whatk = Vector{LazySet{NUM}}(b)
-
-    inputs = next_set(U)
-    @inbounds for i in 1:b
-        bi = partition[blocks[i]]
-        Whatk[i] = overapproximate(blocks[i], proj(bi, n) * inputs)
-    end
     ϕpowerk = copy(ϕ)
+
+    if U != nothing
+        Whatk = Vector{LazySet{NUM}}(b)
+        inputs = next_set(U)
+        @inbounds for i in 1:b
+            bi = partition[blocks[i]]
+            Whatk[i] = overapproximate(blocks[i], proj(bi, n) * inputs)
+        end
+    end
 
     k = 2
     p = Progress(N, 1, "Computing successors ")
@@ -76,7 +78,8 @@ function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
                     Xhatk_bi = Xhatk_bi + block * Xhat0[j]
                 end
             end
-            Xhatk[i] = overapproximate(blocks[i], Xhatk_bi + Whatk[i])
+            Xhatk[i] = overapproximate(blocks[i],
+                U == nothing ? Xhatk_bi : Xhatk_bi + Whatk[i])
         end
         res[k] = CartesianProductArray(copy(Xhatk))
 
@@ -84,58 +87,12 @@ function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
             break
         end
 
-        for i in 1:b
-            bi = partition[blocks[i]]
-            Whatk[i] =
-                overapproximate(blocks[i], Whatk[i] + row(ϕpowerk, bi) * inputs)
-        end
-        ϕpowerk = ϕpowerk * ϕ
-        k += 1
-    end
-
-    return nothing
-end
-
-
-# sparse, no input
-function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
-                                Xhat0::Vector{<:LazySet{NUM}},
-                                overapproximate::Function,
-                                n::Int,
-                                N::Int,
-                                blocks::AbstractVector{Int},
-                                partition::AbstractVector{<:Union{AbstractVector{Int}, Int}},
-                                res::Vector{CartesianProductArray{NUM}}
-                               )::Void where {NUM}
-    res[1] = CartesianProductArray(Xhat0[blocks])
-    if N == 1
-        return nothing
-    end
-
-    b = length(blocks)
-    Xhatk = Vector{LazySet{NUM}}(b)
-
-    ϕpowerk = copy(ϕ)
-
-    k = 2
-    p = Progress(N, 1, "Computing successors ")
-    @inbounds while true
-        update!(p, k)
-        for i in 1:b
-            bi = partition[blocks[i]]
-            Xhatk_bi = ZeroSet(length(bi))
-            for (j, bj) in enumerate(partition)
-                block = ϕpowerk[bi, bj]
-                if findfirst(block) != 0
-                    Xhatk_bi = Xhatk_bi + block * Xhat0[j]
-                end
+        if U != nothing
+            for i in 1:b
+                bi = partition[blocks[i]]
+                Whatk[i] = overapproximate(blocks[i],
+                                           Whatk[i] + row(ϕpowerk, bi) * inputs)
             end
-            Xhatk[i] = overapproximate(blocks[i], Xhatk_bi)
-        end
-        res[k] = CartesianProductArray(copy(Xhatk))
-
-        if k == N
-            break
         end
 
         ϕpowerk = ϕpowerk * ϕ
@@ -145,11 +102,10 @@ function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
     return nothing
 end
 
-
-# dense, with input
+# dense
 function reach_blocks!(ϕ::AbstractMatrix{NUM},
                                 Xhat0::Vector{<:LazySet{NUM}},
-                                U::ConstantNonDeterministicInput,
+                                U::Union{ConstantNonDeterministicInput, Void},
                                 overapproximate::Function,
                                 n::Int,
                                 N::Int,
@@ -164,17 +120,19 @@ function reach_blocks!(ϕ::AbstractMatrix{NUM},
 
     b = length(blocks)
     Xhatk = Vector{LazySet{NUM}}(b)
-    Whatk = Vector{LazySet{NUM}}(b)
-
-    inputs = next_set(U)
-    @inbounds for i in 1:b
-        bi = partition[blocks[i]]
-        Whatk[i] = overapproximate(blocks[i], proj(bi, n) * inputs)
-    end
     ϕpowerk = copy(ϕ)
     ϕpowerk_cache = similar(ϕ)
 
-    arr_length = length(partition) + 1
+    if U != nothing
+        Whatk = Vector{LazySet{NUM}}(b)
+        inputs = next_set(U)
+        @inbounds for i in 1:b
+            bi = partition[blocks[i]]
+            Whatk[i] = overapproximate(blocks[i], proj(bi, n) * inputs)
+        end
+    end
+
+    arr_length = (U == nothing) ? length(partition) : length(partition) + 1
     arr = Vector{LazySet{NUM}}(arr_length)
     k = 2
     p = Progress(N, 1, "Computing successors ")
@@ -185,59 +143,8 @@ function reach_blocks!(ϕ::AbstractMatrix{NUM},
             for (j, bj) in enumerate(partition)
                 arr[j] = ϕpowerk[bi, bj] * Xhat0[j]
             end
-            arr[arr_length] = Whatk[i]
-            Xhatk[i] = overapproximate(blocks[i], MinkowskiSumArray(arr))
-        end
-        res[k] = CartesianProductArray(copy(Xhatk))
-
-        if k == N
-            break
-        end
-
-        for i in 1:b
-            bi = partition[blocks[i]]
-            Whatk[i] =
-                overapproximate(blocks[i], Whatk[i] + row(ϕpowerk, bi) * inputs)
-        end
-        A_mul_B!(ϕpowerk_cache, ϕpowerk, ϕ)
-        copy!(ϕpowerk, ϕpowerk_cache)
-        k += 1
-    end
-
-    return nothing
-end
-
-
-# dense, no input
-function reach_blocks!(ϕ::AbstractMatrix{NUM},
-                                Xhat0::Vector{<:LazySet{NUM}},
-                                overapproximate::Function,
-                                n::Int,
-                                N::Int,
-                                blocks::AbstractVector{Int},
-                                partition::AbstractVector{<:Union{AbstractVector{Int}, Int}},
-                                res::Vector{CartesianProductArray{NUM}}
-                               )::Void where {NUM}
-    res[1] = CartesianProductArray(Xhat0[blocks])
-    if N == 1
-        return nothing
-    end
-
-    b = length(blocks)
-    Xhatk = Vector{LazySet{NUM}}(b)
-
-    ϕpowerk = copy(ϕ)
-    ϕpowerk_cache = similar(ϕ)
-
-    arr = Vector{LazySet{NUM}}(length(partition))
-    k = 2
-    p = Progress(N, 1, "Computing successors ")
-    @inbounds while true
-        update!(p, k)
-        for i in 1:b
-            bi = partition[blocks[i]]
-            for (j, bj) in enumerate(partition)
-                arr[j] = ϕpowerk[bi, bj] * Xhat0[j]
+            if U != nothing
+                arr[arr_length] = Whatk[i]
             end
             Xhatk[i] = overapproximate(blocks[i], MinkowskiSumArray(arr))
         end
@@ -247,18 +154,27 @@ function reach_blocks!(ϕ::AbstractMatrix{NUM},
             break
         end
 
+        if U != nothing
+            for i in 1:b
+                bi = partition[blocks[i]]
+                Whatk[i] = overapproximate(blocks[i],
+                                           Whatk[i] + row(ϕpowerk, bi) * inputs)
+            end
+        end
+
         A_mul_B!(ϕpowerk_cache, ϕpowerk, ϕ)
         copy!(ϕpowerk, ϕpowerk_cache)
+
         k += 1
     end
 
     return nothing
 end
 
-
-# lazymexp, no input
+# lazy_expm
 function reach_blocks!(ϕ::SparseMatrixExp{NUM},
                                 Xhat0::Vector{<:LazySet{NUM}},
+                                U::Union{ConstantNonDeterministicInput, Void},
                                 overapproximate::Function,
                                 n::Int,
                                 N::Int,
@@ -273,8 +189,16 @@ function reach_blocks!(ϕ::SparseMatrixExp{NUM},
 
     b = length(blocks)
     Xhatk = Vector{LazySet{NUM}}(b)
-
     ϕpowerk = SparseMatrixExp(copy(ϕ.M))
+
+    if U != nothing
+        Whatk = Vector{LazySet{NUM}}(b)
+        inputs = next_set(U)
+        @inbounds for i in 1:b
+            bi = partition[blocks[i]]
+            Whatk[i] = overapproximate(blocks[i], proj(bi, n) * inputs)
+        end
+    end
 
     k = 2
     p = Progress(N, 1, "Computing successors ")
@@ -290,66 +214,12 @@ function reach_blocks!(ϕ::SparseMatrixExp{NUM},
                     Xhatk_bi = Xhatk_bi + πbi * Xhat0[j]
                 end
             end
-            Xhatk[i] = overapproximate(blocks[i], Xhatk_bi)
-        end
-        res[k] = CartesianProductArray(copy(Xhatk))
-
-        if k == N
-            break
-        end
-
-        ϕpowerk.M .= ϕpowerk.M + ϕ.M
-        k += 1
-    end
-
-    return nothing
-end
-
-
-# lazymexp, with input
-function reach_blocks!(ϕ::SparseMatrixExp{NUM},
-                                Xhat0::Vector{<:LazySet{NUM}},
-                                U::ConstantNonDeterministicInput,
-                                overapproximate::Function,
-                                n::Int,
-                                N::Int,
-                                blocks::AbstractVector{Int},
-                                partition::AbstractVector{<:Union{AbstractVector{Int}, Int}},
-                                res::Vector{CartesianProductArray{NUM}}
-                               )::Void where {NUM}
-    res[1] = CartesianProductArray(Xhat0[blocks])
-    if N == 1
-        return nothing
-    end
-
-    b = length(blocks)
-    Xhatk = Vector{LazySet{NUM}}(b)
-    Whatk = Vector{LazySet{NUM}}(b)
-
-    inputs = next_set(U)
-    @inbounds for i in 1:b
-        bi = partition[blocks[i]]
-        Whatk[i] = overapproximate(blocks[i], proj(bi, n) * inputs)
-    end
-    ϕpowerk = SparseMatrixExp(copy(ϕ.M))
-
-    k = 2
-    p = Progress(N, 1, "Computing successors ")
-    @inbounds while true
-        update!(p, k)
-        for i in 1:b
-            bi = partition[blocks[i]]
-            ϕpowerk_πbi = get_rows(ϕpowerk, bi)
-            Xhatk_bi = ZeroSet(length(bi))
-            for (j, bj) in enumerate(partition)
-                πbi = block(ϕpowerk_πbi, bj)
-                if findfirst(πbi) != 0
-                    Xhatk_bi = Xhatk_bi + πbi * Xhat0[j]
-                end
+            Xhatk[i] = overapproximate(blocks[i],
+                U == nothing ? Xhatk_bi : Xhatk_bi + Whatk[i])
+            if U != nothing
+                Whatk[i] =
+                    overapproximate(blocks[i], Whatk[i] + ϕpowerk_πbi * inputs)
             end
-            Xhatk[i] = overapproximate(blocks[i], Xhatk_bi + Whatk[i])
-            Whatk[i] =
-                overapproximate(blocks[i], Whatk[i] + ϕpowerk_πbi * inputs)
         end
         res[k] = CartesianProductArray(copy(Xhatk))
 


### PR DESCRIPTION
See #75.

Merges the analysis modes "with inputs" and "without inputs".
The git merge looks ugly, but there were only a few actual changes, namely wrapping the code for "with inputs" in an `if` block.
An inspection with `@code_warntype` shows that the generated code just omits these blocks if there are no inputs, so the performance is the same as before.