### PR TITLE
#190 - Fix deprecation warning in Memento

### DIFF
--- a/src/logging.jl
+++ b/src/logging.jl
@@ -89,7 +89,7 @@ function configure_logger(level::Union{String, Int, Void}=DEFAULT_LOG_LEVEL)
     else
         error("Illegal verbosity input $level.")
     end
-    return Memento.config(level_string; fmt="[{level}] {msg}")
+    return Memento.config!(level_string; fmt="[{level}] {msg}")
 end
 
 """


### PR DESCRIPTION
Closes #190.

(Only merge this when `Memento` has made a new release. The current version, where this fix is not needed and actually crashes, is v0.6.0.)