### PR TITLE
#91 - Fix lazy_X0 option

### DIFF
--- a/src/Properties/check_property.jl
+++ b/src/Properties/check_property.jl
@@ -83,7 +83,7 @@ function check_property(S::AbstractSystem,
         info("- Decomposing X0")
         tic()
         if lazy_X0
-            Xhat0 = S.x0
+            Xhat0 = array(decompose_helper(S.x0, block_sizes, n))
         elseif dir != nothing
             Xhat0 = array(decompose(S.x0, directions=dir, blocks=block_sizes))
         elseif !isempty(kwargs_dict[:block_types_init])

--- a/src/ReachSets/reach.jl
+++ b/src/ReachSets/reach.jl
@@ -87,7 +87,7 @@ function reach(S::AbstractSystem,
         info("- Decomposing X0")
         tic()
         if lazy_X0
-            Xhat0 = S.x0
+            Xhat0 = array(decompose_helper(S.x0, block_sizes, n))
         elseif dir != nothing
             Xhat0 = array(decompose(S.x0, directions=dir, blocks=block_sizes))
         elseif !isempty(kwargs_dict[:block_types_init])

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -27,6 +27,9 @@ export @filename_to_png,
 # internal conversion
 export interpret_template_direction_symbol
 
+# temporary helper function
+export decompose_helper
+
 # Extension of MathematicalSystems for use inside Reachability.jl
 include("systems.jl")
 
@@ -393,6 +396,23 @@ function compute_block_sizes(partition::Union{Vector{Int}, Vector{UnitRange{Int}
         res[i] = length(block)
     end
     return res
+end
+
+"""
+This is a temporary decomposition function that only applies a projection and
+keeps the sets lazy.
+Eventually this should be handled in LazySets.
+"""
+function decompose_helper(S::LazySet{N}, blocks::AbstractVector{Int},
+                          n::Int=dim(S)) where {N}
+    result = Vector{LazySet{N}}(length(blocks))
+    block_start = 1
+    @inbounds for (i, bi) in enumerate(blocks)
+        M = sparse(1:bi, block_start:(block_start + bi - 1), ones(N, bi), bi, n)
+        result[i] = M * S
+        block_start += bi
+    end
+    return CartesianProductArray(result)
 end
 
 end # module


### PR DESCRIPTION
Closes #91.

This is an alternative solution to #112. In this minimally invasive approach here we do the projection but keep it lazy, in #112 the whole set is kept lazy (not even projection).
Closes #112.