### PR TITLE
Adapt to type parameter change in LinearMap

### DIFF
--- a/src/Properties/check_property.jl
+++ b/src/Properties/check_property.jl
@@ -142,7 +142,7 @@ function check_property(S::AbstractSystem,
         @assert lazy_inputs_interval isa Function "illegal internal value " *
             "$lazy_inputs_interval for option :lazy_inputs_interval"
         # first set in a series
-        function _f(k, i, x::LinearMap{MN, NUM}) where {MN, NUM}
+        function _f(k, i, x::LinearMap{NUM}) where {NUM}
             @assert k == 1 "a LinearMap is only expected in the first iteration"
             return CacheMinkowskiSum(LazySet{NUM}[x])
         end

--- a/src/ReachSets/reach.jl
+++ b/src/ReachSets/reach.jl
@@ -144,7 +144,7 @@ function reach(S::AbstractSystem,
         overapproximate_inputs_fun = (k, i, x) -> overapproximate_fun(i, x)
     else
         # first set in a series
-        function _f(k, i, x::LinearMap{MN, NUM}) where {MN, NUM}
+        function _f(k, i, x::LinearMap{NUM}) where {NUM}
             @assert k == 1 "a LinearMap is only expected in the first iteration"
             return CacheMinkowskiSum(LazySet{NUM}[x])
         end


### PR DESCRIPTION
Adapts this package to the change coming in [`LazySets.jl`'s #472](https://github.com/JuliaReach/LazySets.jl/pull/472).