### PR TITLE
Replace unbounded `HPolytope`s by `HPolyhedron`

### DIFF
--- a/test/Reachability/unit_solve_hybrid_bouncing_ball.jl
+++ b/test/Reachability/unit_solve_hybrid_bouncing_ball.jl
@@ -18,7 +18,7 @@ m = [ConstrainedLinearControlContinuousSystem(A, eye(size(B, 1)), X, B*U)];
 
 # Reset maps
 A = [1.0 0.0; 0.0 -0.75];
-X = HPolytope([HalfSpace([0.0, 1.0], 0.0),   # v <= 0
+X = HPolyhedron([HalfSpace([0.0, 1.0], 0.0),   # v <= 0
                HalfSpace([-1.0, 0.0], 0.0),  # x >= 0
                HalfSpace([1.0, 0.0], 0.0)]); # x <= 0
 r = [ConstrainedLinearDiscreteSystem(A, X)];

--- a/test/Reachability/unit_solve_hybrid_bouncing_ball.jl
+++ b/test/Reachability/unit_solve_hybrid_bouncing_ball.jl
@@ -2,28 +2,28 @@
 # See: https://juliareach.github.io/SX.jl/latest/examples/bball.html
 # ============================
 
-using HybridSystems, MathematicalSystems, LazySets, Polyhedra
+using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra, Optim
 import LazySets.HalfSpace
 
 # Transition graph (automaton)
 a = LightAutomaton(1);
 add_transition!(a, 1, 1, 1);
 
-# Modes
+# mode
 A = [0.0 1.0; 0.0 0.0];
 B = reshape([0.0, -1.0], (2, 1));
 X = HalfSpace([-1.0, 0.0], 0.0); # x >= 0
 U = Singleton([1.0]);
 m = [ConstrainedLinearControlContinuousSystem(A, eye(size(B, 1)), X, B*U)];
 
-# Reset maps
+# reset map
 A = [1.0 0.0; 0.0 -0.75];
 X = HPolyhedron([HalfSpace([0.0, 1.0], 0.0),   # v <= 0
-               HalfSpace([-1.0, 0.0], 0.0),  # x >= 0
-               HalfSpace([1.0, 0.0], 0.0)]); # x <= 0
+                 HalfSpace([-1.0, 0.0], 0.0),  # x >= 0
+                 HalfSpace([1.0, 0.0], 0.0)]); # x <= 0
 r = [ConstrainedLinearDiscreteSystem(A, X)];
 
-# Switchings
+# switching
 s = [HybridSystems.AutonomousSwitching()];
 
 HS = HybridSystem(a, m, r, s);
@@ -31,12 +31,12 @@ HS = HybridSystem(a, m, r, s);
 # initial condition in mode 1
 X0 = Hyperrectangle(low=[10, 0.0], high=[10.2, 0.0]);
 
-inits = [(1,X0)]
-
+inits = [(1, X0)]
 
 system = InitialValueProblem(HS, inits);
-options = Options(:mode=>"reach", :vars=>[1,2], :T=>5.0, :δ=>0.1, :plot_vars=>[1, 2],
-                  :max_jumps=>1, :verbosity=>1);
+
+options = Options(:mode=>"reach", :vars=>[1, 2], :T=>5.0, :δ=>0.1,
+                  :plot_vars=>[1, 2], :max_jumps=>1, :verbosity=>1);
 
 # default algorithm
 sol = solve(system, options);

--- a/test/Reachability/unit_solve_hybrid_thermostat.jl
+++ b/test/Reachability/unit_solve_hybrid_thermostat.jl
@@ -29,12 +29,12 @@ m_off = ConstrainedLinearControlContinuousSystem(A, eye(size(B, 1)), X, B*U);
 
 # Transition from on to off
 A = hcat(1.0);
-X = HPolytope([HalfSpace([-1.0], -21.0)]); # x >= 21
+X = HPolyhedron([HalfSpace([-1.0], -21.0)]); # x >= 21
 t_on2off = ConstrainedLinearDiscreteSystem(A, X)
 
 # Transition from off to on
 A = hcat(1.0);
-X = HPolytope([HalfSpace([1.0], 19.0)]); # x <= 19
+X = HPolyhedron([HalfSpace([1.0], 19.0)]); # x <= 19
 t_off2on = ConstrainedLinearDiscreteSystem(A, X)
 
 m = [m_on, m_off];

--- a/test/Reachability/unit_solve_hybrid_thermostat.jl
+++ b/test/Reachability/unit_solve_hybrid_thermostat.jl
@@ -3,56 +3,58 @@
 # Section 1.3.4.
 # ============================
 
-using HybridSystems, MathematicalSystems, LazySets, Polyhedra
+using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra, Optim
 import LazySets.HalfSpace
 import Reachability.ReachSet
 
 c_a = 0.1;
-# Transition graph (automaton)
+
+# transition graph (automaton)
 a = LightAutomaton(2);
 add_transition!(a, 1, 2, 1);
 add_transition!(a, 2, 1, 2);
 
-# Mode on
+# mode on
 A = hcat(-c_a);
 B = hcat(30.);
 X = HalfSpace([1.0], 22.0); # x <= 22
 U = Singleton([c_a]);
 m_on = ConstrainedLinearControlContinuousSystem(A, eye(size(B, 1)), X, B*U);
 
-# Mode off
+# mode off
 A = hcat(-c_a);
 B = hcat(0.0);
 X = HalfSpace([-1.0], -18.0); # x >= 18
 U = Singleton([0.0]);
 m_off = ConstrainedLinearControlContinuousSystem(A, eye(size(B, 1)), X, B*U);
 
-# Transition from on to off
+# transition from on to off
 A = hcat(1.0);
-X = HPolyhedron([HalfSpace([-1.0], -21.0)]); # x >= 21
+X = HalfSpace([-1.0], -21.0); # x >= 21
 t_on2off = ConstrainedLinearDiscreteSystem(A, X)
 
-# Transition from off to on
+# transition from off to on
 A = hcat(1.0);
-X = HPolyhedron([HalfSpace([1.0], 19.0)]); # x <= 19
+X = HalfSpace([1.0], 19.0); # x <= 19
 t_off2on = ConstrainedLinearDiscreteSystem(A, X)
 
 m = [m_on, m_off];
 
 r = [t_on2off, t_off2on];
 
-# Switchings
+# switchings
 s = [HybridSystems.AutonomousSwitching()];
 
 HS = HybridSystem(a, m, r, s);
 
-# initial condition in mode 1
+# initial condition in mode off
 X0 = Singleton([18.]);
+inits = [(2, X0)]
 
 system = InitialValueProblem(HS, X0);
 
 options = Options(:mode=>"reach", :vars=>[1], :T=>5.0, :δ=>0.1,
-                          :max_jumps=>1, :verbosity=>1, :clustering=>:none);
+                  :max_jumps=>1, :verbosity=>1);
 
 # default algorithm
 sol = solve(system, options);


### PR DESCRIPTION
Closes #313.

The models will work after merging open PRs in `LazySets`.
EDIT: Apparently this is not true anymore. We need to have https://github.com/JuliaReach/LazySets.jl/issues/798.