### PR TITLE
preallocated Rsets

### DIFF
--- a/src/ReachSets/DiscretePost/ApproximatingDiscretePost.jl
+++ b/src/ReachSets/DiscretePost/ApproximatingDiscretePost.jl
@@ -62,6 +62,7 @@ function post(op::ApproximatingDiscretePost,
               passed_list,
               source_loc_id,
               tube⋂inv,
+              count_Rsets,
               jumps,
               options
              ) where {N}
@@ -78,8 +79,8 @@ function post(op::ApproximatingDiscretePost,
 
         # perform jumps
         post_jump = Vector{ReachSet{LazySet{N}, N}}()
-        sizehint!(post_jump, length(tube⋂inv))
-        for reach_set in tube⋂inv
+        sizehint!(post_jump, count_Rsets)
+        for reach_set in tube⋂inv[length(tube⋂inv) - count_Rsets + 1 : end]
             # check intersection with guard
             R⋂G = Intersection(reach_set.X, guard)
             if isempty(R⋂G)

--- a/src/ReachSets/DiscretePost/ApproximatingDiscretePost.jl
+++ b/src/ReachSets/DiscretePost/ApproximatingDiscretePost.jl
@@ -35,23 +35,25 @@ function tube⋂inv!(op::ApproximatingDiscretePost,
                    invariant,
                    Rsets,
                    start_interval
-                  )::Vector{ReachSet{LazySet{N}, N}} where {N}
-    intersections = Vector{ReachSet{LazySet{N}, N}}()
+                  ) where {N}
+
     dirs = get_overapproximation_option(op, dim(invariant))
+
+    # counts the number of sets R⋂I added to Rsets
+    count = 0
     for reach_set in reach_tube
         R⋂I = Intersection(invariant, reach_set.X)
         if op.options[:check_invariant_intersection] && isempty(R⋂I)
             break
         end
         # return an overapproximation
-        push!(intersections, ReachSet{LazySet{N}, N}(
+        push!(Rsets, ReachSet{LazySet{N}, N}(
             overapproximate(R⋂I, dirs),
             reach_set.t_start + start_interval[1],
             reach_set.t_end + start_interval[2]))
+        count = count + 1
     end
-
-    append!(Rsets, intersections)
-    return intersections
+    return count
 end
 
 function post(op::ApproximatingDiscretePost,

--- a/src/ReachSets/DiscretePost/LazyTextbookDiscretePost.jl
+++ b/src/ReachSets/DiscretePost/LazyTextbookDiscretePost.jl
@@ -70,6 +70,7 @@ function post(op::LazyTextbookDiscretePost,
               passed_list,
               source_loc_id,
               tube⋂inv,
+              count_Rsets,
               jumps,
               options
              ) where {N}
@@ -93,8 +94,8 @@ function post(op::LazyTextbookDiscretePost,
 
         # perform jumps
         post_jump = Vector{ReachSet{LazySet{N}, N}}()
-        sizehint!(post_jump, length(tube⋂inv))
-        for reach_set in tube⋂inv
+        sizehint!(post_jump, count_Rsets)
+        for reach_set in tube⋂inv[length(tube⋂inv) - count_Rsets + 1 : end]
             # check intersection with guard
             taken_intersection = false
             if inv_isa_Hrep && guard_isa_Hrep && op.options[:lazy_R⋂I]

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -220,7 +220,6 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
         count_Rsets = tube⋂inv!(opD, reach_tube.Xk, loc.X, Rsets,
                                 [X0.t_start, X0.t_end])
 
-        #tube⋂inv = @view Rsets[length(Rsets) - count_Rsets + 1 : end]
         if jumps == max_jumps
             continue
         end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -219,14 +219,14 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
         # count_Rsets counts the number of new reach sets added to Rsets
         count_Rsets = tube⋂inv!(opD, reach_tube.Xk, loc.X, Rsets,
                                 [X0.t_start, X0.t_end])
-        
-        tube⋂inv = @view Rsets[length(Rsets) - count_Rsets + 1 : end]
+
+        #tube⋂inv = @view Rsets[length(Rsets) - count_Rsets + 1 : end]
         if jumps == max_jumps
             continue
         end
-        
-        post(opD, HS, waiting_list, passed_list, loc_id, Rsets, jumps,
-             options)
+
+        post(opD, HS, waiting_list, passed_list, loc_id, Rsets, count_Rsets,
+             jumps, options)
     end
 
     # Projection

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -216,15 +216,17 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
             end
         end
 
+        # count_Rsets counts the number of new reach sets added to Rsets
         count_Rsets = tube⋂inv!(opD, reach_tube.Xk, loc.X, Rsets,
                                 [X0.t_start, X0.t_end])
-
+        
+        tube⋂inv = @view Rsets[length(Rsets) - count_Rsets + 1 : end]
         if jumps == max_jumps
             continue
         end
-
+        
         post(opD, HS, waiting_list, passed_list, loc_id, Rsets, jumps,
-             options, count_Rsets)
+             options)
     end
 
     # Projection

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -216,15 +216,15 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
             end
         end
 
-        tube⋂inv = tube⋂inv!(opD, reach_tube.Xk, loc.X, Rsets,
-                             [X0.t_start, X0.t_end])
+        count_Rsets = tube⋂inv!(opD, reach_tube.Xk, loc.X, Rsets,
+                                [X0.t_start, X0.t_end])
 
         if jumps == max_jumps
             continue
         end
 
-        post(opD, HS, waiting_list, passed_list, loc_id, tube⋂inv, jumps,
-             options)
+        post(opD, HS, waiting_list, passed_list, loc_id, Rsets, jumps,
+             options, count_Rsets)
     end
 
     # Projection


### PR DESCRIPTION
Each discrete post operator implements a [tube⋂inv!](https://github.com/JuliaReach/Reachability.jl/blob/master/src/solve.jl#L219) function that basically calculates the reach pipe obtained by intersecting the output of the continuous post (Rsets) with the invariant. 

Currently `tube⋂inv!` receives `Rsets` and generates a new array, called `intersections` internally, which is immediately appened to `Rsets` [here](https://github.com/JuliaReach/Reachability.jl/blob/master/src/ReachSets/DiscretePost/ApproximatingDiscretePost.jl#L53).

The purpose of this PR is to push each new `R⋂I` to `Rsets` directly.