### PR TITLE
Fast non-zero check for arrays

### DIFF
--- a/src/ReachSets/Properties/check_blocks.jl
+++ b/src/ReachSets/Properties/check_blocks.jl
@@ -67,7 +67,7 @@ function check_blocks(ϕ::SparseMatrixCSC{NUM, Int},
             Xhatk_bi = ZeroSet(length(bi))
             for (j, bj) in enumerate(partition)
                 block = ϕpowerk[bi, bj]
-                if findfirst(block) != 0
+                if hasnz(block)
                     Xhatk_bi = Xhatk_bi + block * Xhat0[j]
                 end
             end
@@ -226,7 +226,7 @@ function check_blocks(ϕ::SparseMatrixExp{NUM},
             Xhatk_bi = ZeroSet(length(bi))
             for (j, bj) in enumerate(partition)
                 πbi = block(ϕpowerk_πbi, bj)
-                if findfirst(πbi) != 0
+                if hasnz(πbi)
                     Xhatk_bi = Xhatk_bi + πbi * Xhat0[j]
                 end
             end

--- a/src/ReachSets/reach_blocks.jl
+++ b/src/ReachSets/reach_blocks.jl
@@ -89,7 +89,7 @@ function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
             Xhatk_bi = ZeroSet(length(bi))
             for (j, bj) in enumerate(partition)
                 block = ϕpowerk[bi, bj]
-                if findfirst(block) != 0
+                if hasnz(block)
                     Xhatk_bi = Xhatk_bi + block * Xhat0[j]
                 end
             end
@@ -267,7 +267,7 @@ function reach_blocks!(ϕ::SparseMatrixExp{NUM},
             Xhatk_bi = ZeroSet(length(bi))
             for (j, bj) in enumerate(partition)
                 πbi = block(ϕpowerk_πbi, bj)
-                if findfirst(πbi) != 0
+                if hasnz(πbi)
                     Xhatk_bi = Xhatk_bi + πbi * Xhat0[j]
                 end
             end

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -36,6 +36,9 @@ export interpret_template_direction_symbol,
 # temporary helper function
 export decompose_helper
 
+# convenience
+export hasnz
+
 # Extension of MathematicalSystems for use inside Reachability.jl
 include("systems.jl")
 
@@ -145,7 +148,7 @@ function print_sparsity(ϕ::AbstractMatrix{Float64}, name::String="")
     @inline F(bi::Int64, bj::Int64) = ϕ[(2*bi-1):(2*bi), (2*bj-1):(2*bj)]
     for bj in 1:b
         for bi in 1:b
-            if findfirst(F(bi, bj)) == 0
+            if !hasnz(F(bi, bj))
                 zero_blocks += 1
             end
         end
@@ -162,7 +165,7 @@ function print_sparsity(ϕ::SparseMatrixExp{Float64}, name::String="")
     for bi in 1:b
         block_row_bi = F(bi)
         for bj in 1:b
-            if findfirst(block_row_bi[1:2, (2*bj-1):(2*bj)]) == 0
+            if !hasnz(block_row_bi[1:2, (2*bj-1):(2*bj)])
                 zero_blocks += 1
             end
         end
@@ -273,6 +276,28 @@ macro relpath(name::String)
         end
         pathdir * $name
     end
+end
+
+"""
+    hasnz(v::AbstractArray{N})::Bool where N<:Real
+
+Check if an array contains a non-zero entry.
+
+### Input
+
+- `a` -- array
+
+### Output
+
+`true` iff the array contains a non-zero entry.
+"""
+@inline function hasnz(a::AbstractArray{N})::Bool where N<:Real
+    @inbounds for e in a
+       if e != zero(N)
+           return true
+       end
+    end
+    return false
 end
 
 """


### PR DESCRIPTION
This also fixes a deprecation warning (see #361).

I first tried with `any(v->v!=0, x)`, but in `@time` this is expensive. Now that I implemented it, I also tried with `@btime`, and then suddently the `any` approach is efficient. I have no idea what is going on here. Should we keep the function nevertheless? It is a bit more readable and shorter to write. And we anyway want to replace `findfirst`.

```julia
# VECTOR

julia> x = [zeros(Int, 10000); 1];

julia> @btime any(v->v!=0, x) # for some reason this is efficient
4.309 μs (0 allocations: 0 bytes)
true

julia> @time any(v->v!=0, x) # for some reason this is not efficient
  0.008472 seconds (8.33 k allocations: 412.224 KiB)
true

julia> @btime findfirst(v->v!=0, x)
  6.021 μs (1 allocation: 16 bytes)
10001

julia> @btime findfirst(x) # deprecated
  74.652 μs (102 allocations: 12.03 KiB)
10001

julia> @btime hasnz(x)
  4.135 μs (0 allocations: 0 bytes)
true

# MATRIX

julia> A = zeros(Int, 1000, 1000); A[1000, 1000] = 1;

julia> @btime any(v->v!=0, A)
  495.742 μs (0 allocations: 0 bytes)
true

julia> @time any(v->v!=0, A)
  0.024356 seconds (8.33 k allocations: 412.224 KiB)
true

julia> @btime findfirst(v->v!=0, A)
  2.883 ms (2 allocations: 64 bytes)
CartesianIndex(1000, 1000)

julia> @btime findfirst(A) # deprecated
  2.838 ms (96 allocations: 11.81 KiB)
CartesianIndex(1000, 1000)

julia> @btime hasnz(A)
  491.539 μs (0 allocations: 0 bytes)
true
```