### PR TITLE
updates discrete post

### DIFF
--- a/src/ReachSets/DiscretePost/ConcreteDiscretePost.jl
+++ b/src/ReachSets/DiscretePost/ConcreteDiscretePost.jl
@@ -28,7 +28,7 @@ struct ConcreteDiscretePost <: DiscretePost
         𝑂copy = copy(𝑂)
         check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:check_invariant_intersection], false)
         check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:overapproximation], Hyperrectangle)
-        return new(defaults)
+        return new(𝑂copy)
     end
 end
 

--- a/src/ReachSets/DiscretePost/ConcreteDiscretePost.jl
+++ b/src/ReachSets/DiscretePost/ConcreteDiscretePost.jl
@@ -4,6 +4,10 @@
 Textbook implementation of a discrete post operator, using concrete polyhedra
 intersections.
 
+### Fields
+
+- `options` -- an `Options` structure that holds the algorithm-specific options
+
 ### Notes
 
 This operator requires that the `Polyhedra` library is loaded,
@@ -19,32 +23,38 @@ Computations with Support Functions](http://spaceex.imag.fr/sites/default/files/
 """
 struct ConcreteDiscretePost <: DiscretePost
     options::Options
+
+    function ConcreteDiscretePost(𝑂::Options)
+        𝑂copy = copy(𝑂)
+        check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:check_invariant_intersection], false)
+        check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:overapproximation], Hyperrectangle)
+        return new(defaults)
+    end
 end
 
-function ConcreteDiscretePost()
-    defaults = Options()
-    setindex!(defaults, Hyperrectangle, :overapproximation)
-    setindex!(defaults, false, :check_invariant_intersection)
-    return ConcreteDiscretePost(defaults)
-end
+# convenience constructor from pairs of symbols
+ConcreteDiscretePost(𝑂::Pair{Symbol,<:Any}...) = ConcreteDiscretePost(Options(Dict{Symbol,Any}(𝑂)))
 
-function init(op::ConcreteDiscretePost, system, options_input)
+# default options for the LazyDiscretePost discrete post operator
+ConcreteDiscretePost() = ConcreteDiscretePost(Options())
+
+init(𝒫::ConcreteDiscretePost, 𝒮::AbstractSystem, 𝑂::Options) = init!(𝒫, 𝒮, copy(𝑂))
+
+function init!(𝒫::ConcreteDiscretePost, 𝒮::AbstractSystem, 𝑂::Options)
     @assert isdefined(Main, :Polyhedra) "this algorithm needs the package " *
             "'Polyhedra' to be loaded"
 
-    options_input.dict[:n] = statedim(system, 1)
+    𝑂.dict[:n] = statedim(𝒮, 1)
 
     # solver-specific options (adds default values for unspecified options)
-    options = validate_solver_options_and_add_default_values!(options_input)
+    𝑂out = validate_solver_options_and_add_default_values!(𝑂)
 
     # Input -> Output variable mapping
-    options.dict[:inout_map] =
-        inout_map_reach(options[:partition], options[:blocks], options[:n])
-
-    return options
+    𝑂out.dict[:inout_map] = inout_map_reach(𝑂out[:partition], 𝑂out[:blocks], 𝑂out[:n])
+    return 𝑂out
 end
 
-function tube⋂inv!(op::ConcreteDiscretePost,
+function tube⋂inv!(𝒫::ConcreteDiscretePost,
                    reach_tube::Vector{<:ReachSet{<:LazySet{N}}},
                    invariant,
                    Rsets,
@@ -70,7 +80,7 @@ function tube⋂inv!(op::ConcreteDiscretePost,
             rs_converted = HPolytope(constraints_list(rs))
         end
         R⋂I = intersection(invariant, rs_converted)
-        if op.options[:check_invariant_intersection] && isempty(R⋂I)
+        if 𝒫.options[:check_invariant_intersection] && isempty(R⋂I)
             break
         end
         push!(Rsets, ReachSet{LazySet{N}, N}(R⋂I,
@@ -82,7 +92,7 @@ function tube⋂inv!(op::ConcreteDiscretePost,
     return count
 end
 
-function post(op::ConcreteDiscretePost,
+function post(𝒫::ConcreteDiscretePost,
               HS::HybridSystem,
               waiting_list::Vector{Tuple{Int, ReachSet{LazySet{N}, N}, Int}},
               passed_list,
@@ -126,7 +136,7 @@ function post(op::ConcreteDiscretePost,
                                                      reach_set.t_end))
         end
 
-        postprocess(op, HS, post_jump, options, waiting_list, passed_list,
+        postprocess(𝒫, HS, post_jump, options, waiting_list, passed_list,
             target_loc_id, jumps)
     end
 end

--- a/src/ReachSets/DiscretePost/LazyDiscretePost.jl
+++ b/src/ReachSets/DiscretePost/LazyDiscretePost.jl
@@ -25,7 +25,7 @@ struct LazyDiscretePost <: DiscretePost
         check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:lazy_R⋂I], false)
         check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:lazy_R⋂G], true)
         check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:lazy_A⌜R⋂G⌟⋂I], true)
-        return new(𝑂)
+        return new(𝑂copy)
     end
 end
 

--- a/src/ReachSets/DiscretePost/LazyDiscretePost.jl
+++ b/src/ReachSets/DiscretePost/LazyDiscretePost.jl
@@ -1,21 +1,30 @@
-# ==============================================================================
-# Textbook implementation of a discrete post operator, but with lazy operations.
-# ==============================================================================
-
 import LazySets.use_precise_ρ
-import Reachability.check_aliases_and_add_default_value!
 
+"""
+    LazyDiscretePost <: DiscretePost
+
+Textbook implementation of a discrete post operator, but with lazy intersections.
+
+### Fields
+
+- `options` -- an `Options` structure that holds the algorithm-specific options
+
+### Algorithm
+
+The algorithm is based on [Flowpipe-Guard Intersection for Reachability
+Computations with Support Functions](http://spaceex.imag.fr/sites/default/files/frehser_adhs2012.pdf).
+"""
 struct LazyDiscretePost <: DiscretePost
     options::Options
 
     function LazyDiscretePost(𝑂::Options)
         𝑂copy = copy(𝑂)
         # TODO: pass 𝑂 directly?
-        check_aliases_and_add_default_value!(𝑂copy.dict, 𝑂.dict, [:check_invariant_intersection], false)
-        check_aliases_and_add_default_value!(𝑂copy.dict, 𝑂.dict, [:overapproximation], Hyperrectangle)
-        check_aliases_and_add_default_value!(𝑂copy.dict, 𝑂.dict, [:lazy_R⋂I], false)
-        check_aliases_and_add_default_value!(𝑂copy.dict, 𝑂.dict, [:lazy_R⋂G], true)
-        check_aliases_and_add_default_value!(𝑂copy.dict, 𝑂.dict, [:lazy_A⌜R⋂G⌟⋂I], true)
+        check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:check_invariant_intersection], false)
+        check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:overapproximation], Hyperrectangle)
+        check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:lazy_R⋂I], false)
+        check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:lazy_R⋂G], true)
+        check_aliases_and_add_default_value!(𝑂.dict, 𝑂copy.dict, [:lazy_A⌜R⋂G⌟⋂I], true)
         return new(𝑂)
     end
 end
@@ -26,7 +35,7 @@ LazyDiscretePost(𝑂::Pair{Symbol,<:Any}...) = LazyDiscretePost(Options(Dict{Sy
 # default options for the LazyDiscretePost discrete post operator
 LazyDiscretePost() = LazyDiscretePost(Options())
 
-init(𝒟::LazyDiscretePost, 𝒮::AbstractSystem, 𝑂::Options) = init!(𝒟, 𝒮, copy(𝑂))
+init(𝒫::LazyDiscretePost, 𝒮::AbstractSystem, 𝑂::Options) = init!(𝒫, 𝒮, copy(𝑂))
 
 # TODO: use 𝑂 only?
 function init!(𝒫::LazyDiscretePost, 𝒮::AbstractSystem, 𝑂::Options)

--- a/src/ReachSets/ReachSets.jl
+++ b/src/ReachSets/ReachSets.jl
@@ -186,6 +186,7 @@ export PostOperator,
 # ========================
 # Reachability Algorithms
 # ========================
+import Reachability.check_aliases_and_add_default_value!
 
 # dictionary of registered algorithms
 available_algorithms = Dict{String, Dict{String, Any}}()


### PR DESCRIPTION
- update ConcreteDiscretePost with a default inner constructor and `options` field
- use correct order for options in check_aliases_and_add_default_value (See #379)