### PR TITLE
Optim import needed in v0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,18 @@ os:
   - linux
 julia:
   - 0.6
-# - 0.7
-# - nightly
+  - 0.7
+  - 1
 notifications:
   email: false
 git:
   depth: 99999999
 
 ## allow failures (tests will run but not make your overall status red)
-#matrix:
-# allow_failures:
-#   - julia: nightly
+matrix:
+ allow_failures:
+   - julia: 0.7
+   - julia: 1
 
 ## uncomment the following lines to override the default test script
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,12 @@ matrix:
 
 ## uncomment the following lines to override the default test script
 script:
- - julia -e 'Pkg.clone(pwd()); Pkg.build("Reachability"); Pkg.checkout("LazySets"); Pkg.test("Reachability"; coverage=true)'
+ - julia -e 'VERSION >= v"0.7-" && using Pkg;
+             VERSION >= v"0.7-" && Pkg.develop("LazySets");
+             Pkg.clone(pwd());
+             VERSION < v"0.7-" && Pkg.checkout("LazySets");
+             Pkg.build("Reachability");
+             Pkg.test("Reachability"; coverage=true)'
 after_success:
   - julia -e 'Pkg.add("Documenter")'
   - julia -e 'cd(Pkg.dir("Reachability")); include(joinpath("docs", "make.jl"))'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
 julia:
   - 0.6
   - 0.7
-  - 1
 notifications:
   email: false
 git:
@@ -15,7 +14,6 @@ git:
 matrix:
  allow_failures:
    - julia: 0.7
-   - julia: 1
 
 ## uncomment the following lines to override the default test script
 script:

--- a/test/Reachability/solve_hybrid_bouncing_ball.jl
+++ b/test/Reachability/solve_hybrid_bouncing_ball.jl
@@ -2,7 +2,7 @@
 # See: https://juliareach.github.io/SX.jl/latest/examples/bball.html
 # ============================
 
-using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra
+using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra, Optim
 import LazySets.HalfSpace
 
 # Transition graph (automaton)

--- a/test/Reachability/solve_hybrid_bouncing_ball.jl
+++ b/test/Reachability/solve_hybrid_bouncing_ball.jl
@@ -2,7 +2,7 @@
 # See: https://juliareach.github.io/SX.jl/latest/examples/bball.html
 # ============================
 
-using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra, Optim
+using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra
 import LazySets.HalfSpace
 
 # Transition graph (automaton)

--- a/test/Reachability/solve_hybrid_thermostat.jl
+++ b/test/Reachability/solve_hybrid_thermostat.jl
@@ -3,7 +3,9 @@
 # Section 1.3.4.
 # ============================
 
-using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra
+using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra, Optim
+
+# fix namamespace conflicts with Polyhedra
 import LazySets.HalfSpace
 import Reachability.ReachSet
 

--- a/test/Reachability/solve_hybrid_thermostat.jl
+++ b/test/Reachability/solve_hybrid_thermostat.jl
@@ -3,7 +3,7 @@
 # Section 1.3.4.
 # ============================
 
-using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra, Optim
+using Reachability, HybridSystems, MathematicalSystems, LazySets, Polyhedra
 
 # fix namamespace conflicts with Polyhedra
 import LazySets.HalfSpace


### PR DESCRIPTION
Optim using is needed in the tests v0.7 

(this is a minimal change; we could otherwise run the `using Optim` inside the functions that need it inside Reachability, but then that's just about the same of adding this package as a requrement for LazySets, no?)