### PR TITLE
#371 - Deprecation warning with tic - tocc

### DIFF
--- a/src/ReachSets/ContinuousPost/BFFPSV18.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18.jl
@@ -81,17 +81,15 @@ function post(𝒫::BFFPSV18, 𝒮::AbstractSystem, invariant, 𝑂::Options)
 
     if 𝑂[:mode] == "reach"
         info("Reachable States Computation...")
-        tic()
-        Rsets = reach(𝒮, invariant, 𝑂)
-        info("- Total")
-        tocc()
+        @timing begin
+            Rsets = reach(𝒮, invariant, 𝑂)
+            info("- Total")
+        end
 
         # Projection
         if 𝑂[:project_reachset] || 𝑂[:projection_matrix] != nothing
             info("Projection...")
-            tic()
-            RsetsProj = project(Rsets, 𝑂)
-            tocc()
+            RsetsProj = @timing project(Rsets, 𝑂)
         else
             RsetsProj = Rsets
         end
@@ -108,10 +106,10 @@ function post(𝒫::BFFPSV18, 𝒮::AbstractSystem, invariant, 𝑂::Options)
         # Property checking
         # =================
         info("Property Checking...")
-        tic()
-        answer = check_property(𝒮, 𝑂)
-        info("- Total")
-        tocc()
+        @timing begin
+            answer = check_property(𝒮, 𝑂)
+            info("- Total")
+        end
 
         if answer == 0
             info("The property is satisfied!")

--- a/src/ReachSets/ReachSets.jl
+++ b/src/ReachSets/ReachSets.jl
@@ -94,7 +94,7 @@ import LazySets.Approximations:symmetric_interval_hull,
                                decompose,
                                overapproximate,
                                box_approximation
-import Reachability:tocc,
+import Reachability:@timing,
                     Options,
                     validate_solver_options_and_add_default_values!
 

--- a/src/ReachSets/reach.jl
+++ b/src/ReachSets/reach.jl
@@ -64,21 +64,22 @@ function reach(S::Union{IVP{<:LDS{NUM}, <:LazySet{NUM}},
         Xhat0 = LazySet{NUM}[S.x0]
     else
         info("- Decomposing X0")
-        tic()
-        if options[:lazy_X0]
-            Xhat0 = array(decompose_helper(S.x0, block_sizes, n))
-        elseif dir != nothing
-            Xhat0 = array(decompose(S.x0, directions=dir, blocks=block_sizes))
-        elseif !isempty(options[:block_types_init])
-            Xhat0 = array(decompose(S.x0, ε=ε_init,
-                                    block_types=options[:block_types_init]))
-        elseif set_type_init == LazySets.Interval
-            Xhat0 = array(decompose(S.x0, set_type=set_type_init, ε=ε_init,
-                                    blocks=ones(Int, n)))
-        else
-            Xhat0 = array(decompose(S.x0, set_type=set_type_init, ε=ε_init))
+        @timing begin
+            if options[:lazy_X0]
+                Xhat0 = array(decompose_helper(S.x0, block_sizes, n))
+            elseif dir != nothing
+                Xhat0 = array(decompose(S.x0, directions=dir,
+                                        blocks=block_sizes))
+            elseif !isempty(options[:block_types_init])
+                Xhat0 = array(decompose(S.x0, ε=ε_init,
+                                        block_types=options[:block_types_init]))
+            elseif set_type_init == LazySets.Interval
+                Xhat0 = array(decompose(S.x0, set_type=set_type_init, ε=ε_init,
+                                        blocks=ones(Int, n)))
+            else
+                Xhat0 = array(decompose(S.x0, set_type=set_type_init, ε=ε_init))
+            end
         end
-        tocc()
     end
 
     # determine output function: linear map with the given matrix
@@ -203,14 +204,14 @@ function reach(S::Union{IVP{<:LDS{NUM}, <:LazySet{NUM}},
 
     # call the adequate function with the given arguments list
     info("- Computing successors")
-    tic()
-    index, skip = available_algorithms[algorithm_backend]["func"](args...)
-    if index < N || skip
-        # shrink result array
-        info("terminated prematurely, only computed $index/$N steps")
-        deleteat!(res, (skip ? index : index + 1):N)
+    @timing begin
+        index, skip = available_algorithms[algorithm_backend]["func"](args...)
+        if index < N || skip
+            # shrink result array
+            info("terminated prematurely, only computed $index/$N steps")
+            deleteat!(res, (skip ? index : index + 1):N)
+        end
     end
-    tocc()
 
     # return the result
     return res
@@ -224,16 +225,16 @@ function reach(system::IVP{<:AbstractContinuousSystem},
     # Time discretization
     # ===================
     info("Time discretization...")
-    tic()
-    Δ = discretize(
-        system,
-        options[:δ],
-        approx_model=options[:approx_model],
-        pade_expm=options[:pade_expm],
-        lazy_expm=options[:lazy_expm_discretize],
-        lazy_sih=options[:lazy_sih]
+    Δ = @timing begin
+        discretize(
+            system,
+            options[:δ],
+            approx_model=options[:approx_model],
+            pade_expm=options[:pade_expm],
+            lazy_expm=options[:lazy_expm_discretize],
+            lazy_sih=options[:lazy_sih]
         )
-    tocc()
+    end
     Δ = matrix_conversion_lazy_explicit(Δ, options)
     return reach(Δ, invariant, options)
 end

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -8,7 +8,7 @@ using LazySets, MathematicalSystems
 
 include("../compat.jl")
 
-import Reachability.tocc
+import Reachability.@timing
 
 # Visualization
 export print_sparsity,
@@ -497,17 +497,17 @@ function matrix_conversion_lazy_explicit(Δ, options)
     A = Δ.s.A
     if !options[:lazy_expm] && options[:lazy_expm_discretize]
         info("Making lazy matrix exponential explicit...")
-        tic()
-        n = options.dict[:n]
-        if options[:assume_sparse]
-            B = sparse(Int[], Int[], eltype(A)[], n, n)
-        else
-            B = Matrix{eltype(A)}(n, n)
+        @timing begin
+            n = options.dict[:n]
+            if options[:assume_sparse]
+                B = sparse(Int[], Int[], eltype(A)[], n, n)
+            else
+                B = Matrix{eltype(A)}(n, n)
+            end
+            for i in 1:n
+                B[i, :] = get_row(A, i)
+            end
         end
-        for i in 1:n
-            B[i, :] = get_row(A, i)
-        end
-        tocc()
     else
         B = nothing
     end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -8,7 +8,7 @@ using Compat: copyto!, axes, argmax
 import Compat.String
 using Compat.LinearAlgebra
 import Compat.LinearAlgebra: norm, checksquare, LAPACKException,
-                             SingularException, eye, ×
+                             SingularException, ×
 import Compat.InteractiveUtils.subtypes
 export _At_mul_B, _A_mul_B!
 
@@ -26,4 +26,6 @@ end
 
 if VERSION > v"1.0-"
     export eye
+else
+    import Compat.LinearAlgebra.eye
 end

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,7 +1,7 @@
 import Base: info, warn, toc
 import Memento: debug
 
-export info, warn, debug, tocc,
+export info, warn, debug, @timing,
        configure_logger, add_file_logger
 
 global LOGGER = Memento.getlogger(@__MODULE__)
@@ -48,16 +48,40 @@ Prints a message on debug level.
 end
 
 """
-    tocc(func)
+    @timing(expr, [func]=info)
 
-Prints the output of `toc()` using the given log function (default: `info`).
+Executes the expression `expr` and prints the elapsed time using the given log
+function.
 
 ### Input
 
-- `func` - (optional, default: `info`) log function
+- `expr` -- expression
+- `func` -- (optional, default: `info`) log function
+
+### Output
+
+The result of evaluating the expression `expr`.
+
+### Notes
+
+This function is taken from the
+[Julia documentation](https://docs.julialang.org/en/v1/manual/metaprogramming/#Hygiene-1).
+
+### Examples
+
+```julia
+julia> @timing(1+1)
+[info | Reachability]: elapsed time: 1.269e-6 seconds
+```
 """
-@inline function tocc(func::Function=info)
-    func("elapsed time: $(toq()) seconds")
+macro timing(expr, func=info)
+    return quote
+        local t0 = time()
+        local val = $(esc(expr))
+        local t1 = time()
+        $func("elapsed time: " * string(t1 - t0) * " seconds")
+        val
+    end
 end
 
 """

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,4 +1,6 @@
-import Base: info, warn
+@static if VERSION < v"1.0-"
+    import Base: info, warn
+end
 import Memento: debug
 
 export info, warn, debug, @timing,

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -82,7 +82,7 @@ macro timing(expr, func=info, digits=2)
         local t0 = time()
         local val = $(esc(expr))
         local t1 = time()
-        $func("elapsed time: " * string(round(t1 - t0, digits=$digits)) *
+        $func("elapsed time: " * string(Compat.round(t1 - t0, digits=$digits)) *
               " seconds")
         val
     end

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -55,12 +55,15 @@ function.
 
 ### Input
 
-- `expr` -- expression
-- `func` -- (optional, default: `info`) log function
+- `expr`   -- expression
+- `func`   -- (optional, default: `info`) log function
+- `digits` -- (optional, default: `2`) number of digits after the decimal point
+              for timing output
 
 ### Output
 
-The result of evaluating the expression `expr`.
+The macro returns the result of evaluating the expression `expr`.
+The timing information is printed to the logger.
 
 ### Notes
 
@@ -74,12 +77,13 @@ julia> @timing(1+1)
 [info | Reachability]: elapsed time: 1.269e-6 seconds
 ```
 """
-macro timing(expr, func=info)
+macro timing(expr, func=info, digits=2)
     return quote
         local t0 = time()
         local val = $(esc(expr))
         local t1 = time()
-        $func("elapsed time: " * string(t1 - t0) * " seconds")
+        $func("elapsed time: " * string(round(t1 - t0, digits=$digits)) *
+              " seconds")
         val
     end
 end

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,4 +1,4 @@
-import Base: info, warn, toc
+import Base: info, warn
 import Memento: debug
 
 export info, warn, debug, @timing,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -81,10 +81,8 @@ function solve!(system::InitialValueProblem{<:Union{AbstractContinuousSystem,
     options[:transformation_matrix] = nothing
     if options[:coordinate_transformation] != ""
         info("Transformation...")
-        tic()
         (system, transformation_matrix) =
-            transform(system, options[:coordinate_transformation])
-        tocc()
+            @timing transform(system, options[:coordinate_transformation])
         options[:transformation_matrix] = transformation_matrix
         invariant = options[:coordinate_transformation] * invariant
     end
@@ -245,9 +243,7 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
     # Projection
     if options[:project_reachset] || options[:projection_matrix] != nothing
         info("Projection...")
-        tic()
-        RsetsProj = project(Rsets, options)
-        tocc()
+        RsetsProj = @timing project(Rsets, options)
     else
         RsetsProj = Rsets
     end


### PR DESCRIPTION
Closes #371.
Closes #408.

I am not too happy with the output format, but I find it acceptable:
```julia
elapsed time: 7.152557373046875e-6 seconds
```
But I did not find an easy way to control that.
There is [`@printf`](https://stackoverflow.com/questions/24580334/jula-repl-number-formatting#24593139), but this requires another (standard) package.