### PR TITLE
Use sigdigits in logging

### DIFF
--- a/src/logging.jl
+++ b/src/logging.jl
@@ -79,12 +79,12 @@ julia> @timing(1+1)
 [info | Reachability]: elapsed time: 1.269e-6 seconds
 ```
 """
-macro timing(expr, func=info, digits=2)
+macro timing(expr, func=info, sigdigits=3)
     return quote
         local t0 = time()
         local val = $(esc(expr))
         local t1 = time()
-        $func("elapsed time: " * string(Compat.round(t1 - t0, digits=$digits)) *
+        $func("elapsed time: " * string(Compat.round(t1 - t0, sigdigits=$sigdigits)) *
               " seconds")
         val
     end

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,6 +1,10 @@
 @static if VERSION < v"1.0-"
     import Base: info, warn
 end
+
+@static if VERSION >= v"0.7"
+    using Printf
+end
 import Memento: debug
 
 export info, warn, debug, @timing,
@@ -76,7 +80,8 @@ This function is taken from the
 
 ```julia
 julia> @timing(1+1)
-[info | Reachability]: elapsed time: 1.269e-6 seconds
+[info | Reachability]: elapsed time: 1.269e-06 seconds
+2
 ```
 """
 macro timing(expr, func=info, sigdigits=3)
@@ -84,8 +89,7 @@ macro timing(expr, func=info, sigdigits=3)
         local t0 = time()
         local val = $(esc(expr))
         local t1 = time()
-        $func("elapsed time: " * string(Compat.round(t1 - t0, sigdigits=$sigdigits)) *
-              " seconds")
+        $func(@sprintf "elapsed time: %1.3e seconds" t1-t0)
         val
     end
 end

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -63,8 +63,6 @@ function.
 
 - `expr`   -- expression
 - `func`   -- (optional, default: `info`) log function
-- `digits` -- (optional, default: `2`) number of digits after the decimal point
-              for timing output
 
 ### Output
 
@@ -84,7 +82,7 @@ julia> @timing(1+1)
 2
 ```
 """
-macro timing(expr, func=info, sigdigits=3)
+macro timing(expr, func=info)
     return quote
         local t0 = time()
         local val = $(esc(expr))


### PR DESCRIPTION
This is related to #407.

Using `digits` argument:

```julia
julia> s = solve(InitialValueProblem(LinearContinuousSystem(A), X0), :T=>0.1, :verbosity=>1);
[info] Reachable States Computation...
[info] Time discretization...
[info] elapsed time: 0.0 seconds
[info] - Decomposing X0
[info] elapsed time: 0.0 seconds
[info] - Computing successors
[info] elapsed time: 0.0 seconds
[info] - Total
[info] elapsed time: 0.0 seconds
[info] Projection...
[info] elapsed time: 0.0 seconds
```

Using `sigdigits` argument:

```julia
julia> s = solve(InitialValueProblem(LinearContinuousSystem(A), X0), :T=>0.1, :verbosity=>1);
[info] Reachable States Computation...
[info] Time discretization...
[info] elapsed time: 0.000193 seconds
[info] - Decomposing X0
[info] elapsed time: 7.39e-5 seconds
[info] - Computing successors
[info] elapsed time: 0.00287 seconds
[info] - Total
[info] elapsed time: 0.00375 seconds
[info] Projection...
[info] elapsed time: 0.00117 seconds
```