### PR TITLE
Refactoring in solve.jl

### DIFF
--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -4,7 +4,7 @@ decompositions and visualization.
 """
 module Utils
 
-using LazySets, MathematicalSystems
+using LazySets, MathematicalSystems, HybridSystems
 
 include("../compat.jl")
 

--- a/src/Utils/systems.jl
+++ b/src/Utils/systems.jl
@@ -201,11 +201,17 @@ end
 """
     constrained_dimensions(HS::HybridSystem)::Dict{Int,Vector{Int}}
 
-Return all coordinates which appear in any guard or invariant constraint for each location.
+For each location, compute all dimensions that are constrained in the invariant
+or the guard of any outgoing transition.
 
 ### Input
 
 - `HS`  -- hybrid system
+
+### Output
+
+A dictionary mapping the index of each location ``ℓ`` to the dimension indices
+that are constrained in ``ℓ``.
 """
 function constrained_dimensions(HS::HybridSystem)::Dict{Int,Vector{Int}}
     result = Dict{Int,Vector{Int}}()

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -125,7 +125,7 @@ end
 
 # if the initial states are distributed, no need to call distribute_initial_set(system)
 function solve(system::InitialValueProblem{<:HybridSystem,
-                                           <:Vector{<:Tuple{Int64,<:LazySet{N}}}},
+                                           <:Vector{<:Tuple{Int64,<:LazySet}}},
                options::Options,
                opC::ContinuousPost=BFFPSV18(),
                opD::DiscretePost=LazyDiscretePost())::AbstractSolution

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -125,7 +125,7 @@ end
 
 # if the initial states are distributed, no need to call distribute_initial_set(system)
 function solve(system::InitialValueProblem{<:HybridSystem,
-                                           <:Vector{<:Tuple{Int64,<:LazySets.LazySet{N}}}},
+                                           <:Vector{<:Tuple{Int64,<:LazySet{N}}}},
                options::Options,
                opC::ContinuousPost=BFFPSV18(),
                opD::DiscretePost=LazyDiscretePost())::AbstractSolution
@@ -133,7 +133,7 @@ function solve(system::InitialValueProblem{<:HybridSystem,
 end
 
 function solve!(system::InitialValueProblem{<:HybridSystem,
-                                            <:Vector{<:Tuple{Int64,<:LazySets.LazySet{N}}}},
+                                            <:Vector{<:Tuple{Int64,<:LazySet{N}}}},
                options_input::Options,
                opC::ContinuousPost,
                opD::DiscretePost


### PR DESCRIPTION
This branch:

- Adds docstrings to `default_operator` and `distribute_initial_set` (previously named `init_states_from_init_sys`)
- Moves `constrained_dimensions(HS::HybridSystem)` to `Utils` 
- Removes the tuple version of `default_operator` for hybrid systems.