### PR TITLE
Use dev version for MathematicalSystems & HybridSystems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
 script:
  - julia -e 'using Pkg;
              Pkg.develop("LazySets");
+             Pkg.develop("MathematicalSystems");
+             Pkg.develop("HybridSystems");
              Pkg.clone(pwd());
              Pkg.build("Reachability");
              Pkg.test("Reachability"; coverage=true)'


### PR DESCRIPTION
Reason: Currently the new releases of `MathematicalSystems` and `HybridSystems` are not found on `METADATA`. There are investigations, but the show must go on here.