### PR TITLE
WIP - Revise decompose options

### DIFF
--- a/src/ReachSets/ContinuousPost/BFFPSV18/BFFPSV18.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18/BFFPSV18.jl
@@ -174,14 +174,14 @@ since one can choose different partitions and different set representations.
 
 These notes illustrate the options that can be passed to the solver. We begin
 by explaining the default options used by the algorithm. Then we show how to
-specify the computation of a subset of the reachpipe, which helps to improve
+specify the computation of a subset of the flowpipe, which helps to improve
 performance, specially for large systems.
 
-We continue to show some lower-level options such has how to specify a custom
+We continue to show some lower-level options such as how to specify a custom
 block decomposition (the set types used and the sizes of the blocks). 
 
 We conclude showing that there are two different *modes* of operation:
-reachpipe computation and safety property checking, and examples of use.
+flowpipe computation and safety property checking, and examples of use.
 
 #### Running example and default options
 

--- a/src/ReachSets/ContinuousPost/BFFPSV18/BFFPSV18.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18/BFFPSV18.jl
@@ -176,7 +176,7 @@ juoia> problem = InitialValueProblem(LinearContinuousSystem(A), X₀);
 
 julia> sol = solve(problem, Options(:T=>5.0), op=BFFPSV18(Options(:δ=>0.04)));
 ```
-Let's check that the dimension of the first set computed is 2:
+Let's check that the dimension of the first set computed is 5:
 
 ```jldoctest BFFPSV18_example_1
 julia> dim(first(sol.Xk).X)
@@ -190,10 +190,8 @@ julia> sol.options[:partition]
  [4]
  [5]
 ```
-Here, `[1]` corresponds to a block of size one for variable `5`, etc until variable
+Here, `[1]` corresponds to a block of size one for variable `5`, etc., until variable
 `5`. Let's check the set type used is interval:
-
-# FIX: to use Interval for 1D partitions by default
 
 ```jldoctest BFFPSV18_example_1
 julia> sol.options[:set_type]
@@ -212,7 +210,7 @@ julia> sol = solve(problem, Options(:T=>5.0), op=BFFPSV18(Options(:δ=>0.04, :va
 julia> dim(first(sol.Xk).X)
 2
 ```
-The set types used are still intevals:
+The sets used are intevals:
 
 ```jldoctest BFFPSV18_example_1
 julia> all([Xi isa Hyperrectangle for Xi in first(sol.Xk).X.array])


### PR DESCRIPTION
This depends on https://github.com/JuliaReach/LazySets.jl/pull/1179.

To-do's:

- show example of `block_options`
- add an example for the old behavior of `lazy_X0`, to be used as: `:block_options_init => LinearMap`
- add an example passing vars and partition, which means that the algorithm computes *all blocks that contain variables in vars". see also https://github.com/JuliaReach/Reachability.jl/blob/master/src/ReachSets/ContinuousPost/BFFPSV18/BFFPSV18.jl#L298
- explain how to use some of the features wanted in [this issue](https://github.com/JuliaReach/Reachability.jl/issues/92#issuecomment-391033356)