### PR TITLE
#482 - Support partial property mappings

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -195,7 +195,7 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
                        property
         if property_loc != nothing
             for (i, reach_set) in enumerate(reach_tube.Xk)
-                if !check_property(reach_set.X, property_loc)
+                if !check(property_loc, reach_set.X)
                     return CheckSolution(false, i, options)
                 end
             end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -189,9 +189,11 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
                             op=opC,
                             invariant=source_invariant)
         inout_map = reach_tube.options[:inout_map]  # TODO temporary hack
-        if property != nothing
-            # get the property for the current location
-            property_loc = property isa Dict ? property[loc] : property
+        # get the property for the current location
+        property_loc = property isa Dict ?
+                       get(property, loc_id, nothing) :
+                       property
+        if property_loc != nothing
             for (i, reach_set) in enumerate(reach_tube.Xk)
                 if !check_property(reach_set.X, property_loc)
                     return CheckSolution(false, i, options)


### PR DESCRIPTION
Closes #482.

There are also two bugfixes here. Property checking in the hybrid setting did not work at all :astonished:
1. The call to check a property has changed recently, but was not updated here.
2. Properties given as mappings "location index → property" were accessed with the location itself (instead of the index).