### PR TITLE
#471 - Merge overapproximation options

### DIFF
--- a/src/ReachSets/ContinuousPost/BFFPSV18/check_property.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18/check_property.jl
@@ -35,8 +35,7 @@ function check_property(S::IVP{<:AbstractDiscreteSystem},
     n = statedim(S)
     blocks = options[:blocks]
     partition = convert_partition(options[:partition])
-    dir = interpret_template_direction_symbol(
-        options[:template_directions_init])
+    dir = template_direction_symbols[options[:template_directions_init]]
     block_sizes = compute_block_sizes(partition)
     N = ceil(Int, options[:T] / options[:δ])
     ε_init = options[:ε_init]
@@ -90,8 +89,7 @@ function check_property(S::IVP{<:AbstractDiscreteSystem},
     push!(args, U)
 
     # raw overapproximation function
-    dir = interpret_template_direction_symbol(
-        options[:template_directions_iter])
+    dir = template_direction_symbols[options[:template_directions_iter]]
     if dir != nothing
         overapproximate_fun =
             (i, x) -> overapproximate(x, dir(length(partition[i])))

--- a/src/ReachSets/ContinuousPost/BFFPSV18/check_property.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18/check_property.jl
@@ -35,13 +35,7 @@ function check_property(S::IVP{<:AbstractDiscreteSystem},
     n = statedim(S)
     blocks = options[:blocks]
     partition = convert_partition(options[:partition])
-    dir = template_direction_symbols[options[:template_directions_init]]
-    block_sizes = compute_block_sizes(partition)
     N = ceil(Int, options[:T] / options[:δ])
-    ε_init = options[:ε_init]
-    set_type_init = options[:set_type_init]
-    ε_iter = options[:ε_iter]
-    set_type_iter = options[:set_type_iter]
 
     # Cartesian decomposition of the initial set
     if length(partition) == 1 && length(partition[1]) == n
@@ -50,22 +44,8 @@ function check_property(S::IVP{<:AbstractDiscreteSystem},
     else
         info("- Decomposing X0")
         @timing begin
-            if options[:lazy_X0]
-                Xhat0 = array(decompose_helper(S.x0, block_sizes, n))
-            elseif dir != nothing
-                Xhat0 = array(decompose(S.x0, directions=dir,
-                                        blocks=block_sizes))
-            elseif options[:block_types_init] != nothing &&
-                    !isempty(options[:block_types_init])
-                Xhat0 = array(decompose(S.x0, ε=ε_init,
-                                        block_types=options[:block_types_init]))
-            elseif set_type_init == LazySets.Interval
-                Xhat0 = array(decompose(S.x0, set_type=set_type_init, ε=ε_init,
-                                        blocks=ones(Int, n)))
-            else
-                Xhat0 = array(decompose(S.x0, set_type=set_type_init, ε=ε_init,
-                                        blocks=block_sizes))
-            end
+            Xhat0 = array(decompose(S.x0, options[:partition],
+                                    options[:block_options_init]))
         end
     end
 
@@ -88,21 +68,15 @@ function check_property(S::IVP{<:AbstractDiscreteSystem},
     end
     push!(args, U)
 
-    # raw overapproximation function
-    dir = template_direction_symbols[options[:template_directions_iter]]
-    if dir != nothing
-        overapproximate_fun =
-            (i, x) -> overapproximate(x, dir(length(partition[i])))
-    elseif options[:block_types_iter] != nothing
-        block_types_iter = block_to_set_map(options[:block_types_iter])
-        overapproximate_fun = (i, x) -> block_types_iter[i] == HPolygon ?
-                              overapproximate(x, HPolygon, ε_iter) :
-                              overapproximate(x, block_types_iter[i])
-    elseif ε_iter < Inf
-        overapproximate_fun =
-            (i, x) -> overapproximate(x, set_type_iter, ε_iter)
+    # overapproximation function for states
+    block_options_iter = options[:block_options_iter]
+    if block_options_iter isa AbstractVector ||
+            block_options_iter isa Dict{Int, Any}
+        # individual overapproximation options per block
+        overapproximate_fun = (i, X) -> overapproximate(X, block_options_iter[i])
     else
-        overapproximate_fun = (i, x) -> overapproximate(x, set_type_iter)
+        # uniform overapproximation options for each block
+        overapproximate_fun = (i, X) -> overapproximate(X, block_options_iter)
     end
 
     # overapproximate function for inputs
@@ -117,7 +91,7 @@ function check_property(S::IVP{<:AbstractDiscreteSystem},
         end
         # further sets of the series
         function _f(k, i, x::MinkowskiSum{NUM, <:CacheMinkowskiSum}) where NUM
-            if ε_iter == Inf
+            if has_constant_directions(block_options_iter, i)
                 # forget sets if we do not use epsilon-close approximation
                 forget_sets!(x.X)
             end

--- a/src/ReachSets/ContinuousPost/BFFPSV18/reach.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18/reach.jl
@@ -48,8 +48,7 @@ function reach(S::Union{IVP{<:LDS{NUM}, <:LazySet{NUM}},
     n = statedim(S)
     blocks = options[:blocks]
     partition = convert_partition(options[:partition])
-    dir = interpret_template_direction_symbol(
-        options[:template_directions_init])
+    dir = template_direction_symbols[options[:template_directions_init]]
     block_sizes = compute_block_sizes(partition)
     N = ceil(Int, options[:T] / options[:δ])
     ε_init = options[:ε_init]
@@ -115,8 +114,7 @@ function reach(S::Union{IVP{<:LDS{NUM}, <:LazySet{NUM}},
     push!(args, U)
 
     # overapproximation function for states
-    dir = interpret_template_direction_symbol(
-        options[:template_directions_iter])
+    dir = template_direction_symbols[options[:template_directions_iter]]
     if dir != nothing
         overapproximate_fun = (i, x) -> overapproximate(x, dir(length(partition[i])))
     elseif options[:block_types_iter] != nothing

--- a/src/ReachSets/DiscretePost/DiscretePost.jl
+++ b/src/ReachSets/DiscretePost/DiscretePost.jl
@@ -105,7 +105,7 @@ end
 function get_overapproximation_option(𝒫::DiscretePost, n::Int)
     oa = 𝒫.options[:overapproximation]
     if oa isa Symbol
-        dirs = Utils.interpret_template_direction_symbol(oa)
+        dirs = Utils.template_direction_symbols[oa]
         return dirs(n)
     elseif oa <: LazySets.LazySet
         return oa

--- a/src/ReachSets/ReachSets.jl
+++ b/src/ReachSets/ReachSets.jl
@@ -17,7 +17,8 @@ include("../compat.jl")
 using LazySets.Approximations: symmetric_interval_hull,
                                decompose,
                                overapproximate,
-                               box_approximation
+                               box_approximation,
+                               AbstractDirections
 using Reachability: @timing,
                     Options, OptionSpec, TwoLayerOptions, AbstractOptions,
                     validate_and_wrap_options, print_option_spec,

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -29,7 +29,7 @@ export @filename_to_png,
        @relpath
 
 # internal conversion
-export interpret_template_direction_symbol,
+export template_direction_symbols,
        matrix_conversion,
        matrix_conversion_lazy_explicit
 
@@ -407,34 +407,11 @@ function convert_partition(partition::AbstractVector{<:AbstractVector{Int}})::Un
     return partition_out
 end
 
-"""
-    interpret_template_direction_symbol(symbol::Symbol)
-
-Return a template direction type for a given symbol.
-
-### Input
-
-- `symbol` -- symbol
-
-### Output
-
-The template direction type if it is known, or `nothing` otherwise.
-"""
-function interpret_template_direction_symbol(symbol::Symbol)
-    if symbol == :box
-        dir = Approximations.BoxDirections
-    elseif symbol == :oct
-        dir = Approximations.OctDirections
-    elseif symbol == :boxdiag
-        dir = Approximations.BoxDiagDirections
-    else
-        if symbol != :nothing
-            warn("ignoring unknown template direction $symbol")
-        end
-        dir = nothing
-    end
-    return dir
-end
+template_direction_symbols = Dict(
+    :box     => Approximations.BoxDirections,
+    :oct     => Approximations.OctDirections,
+    :boxdiag => Approximations.BoxDiagDirections
+    )
 
 """
     compute_block_sizes(partition::Union{Vector{Int}, Vector{UnitRange{Int}}}

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -20,9 +20,7 @@ export print_sparsity,
 # Block Structure
 export @block_id,
        add_dimension,
-       block_to_set_map,
-       convert_partition,
-       compute_block_sizes
+       convert_partition
 
 # Usability
 export @filename_to_png,
@@ -32,9 +30,6 @@ export @filename_to_png,
 export template_direction_symbols,
        matrix_conversion,
        matrix_conversion_lazy_explicit
-
-# temporary helper function
-export decompose_helper
 
 # Extension of MathematicalSystems for use inside Reachability.jl
 include("systems.jl")
@@ -328,35 +323,6 @@ macro relpath(name::String)
 end
 
 """
-    block_to_set_map(dict::Dict{Type{<:LazySet},
-                                AbstractVector{<:AbstractVector{Int}}})
-
-Invert a map (set type -> block structure) to a map (block index -> set type).
-
-### Input
-
-- `dict` -- map (set type -> block structure)
-
-### Ouput
-
-Vector mapping a block index to the respective set type.
-"""
-function block_to_set_map(dict::Dict{Type{<:LazySet},
-                                     AbstractVector{<:AbstractVector{Int}}})
-    # we assume that blocks do not overlap
-    set_type = Vector{Type{<:LazySet}}()
-    initial_block_indices = Vector{Int}()
-    @inbounds for (key, val) in dict
-        for bi in val
-            push!(set_type, key)
-            push!(initial_block_indices, bi[1])
-        end
-    end
-    s = sortperm(initial_block_indices)
-    return set_type[s]
-end
-
-"""
     convert_partition(partition::AbstractVector{<:AbstractVector{Int}})::Union{
         Vector{Int}, Vector{UnitRange{Int}}, Vector{Union{UnitRange{Int}, Int}}}
 
@@ -412,46 +378,6 @@ template_direction_symbols = Dict(
     :oct     => Approximations.OctDirections,
     :boxdiag => Approximations.BoxDiagDirections
     )
-
-"""
-    compute_block_sizes(partition::Union{Vector{Int}, Vector{UnitRange{Int}}}
-                       )::Vector{Int}
-
-Conversion of the blocks representation from partition to block sizes.
-
-### Input
-
-- `partition` -- partition, a vector of block index ranges
-
-### Output
-
-A vector where the ``i``th entry contains the size of the ``i``th block.
-"""
-function compute_block_sizes(partition::Union{Vector{Int}, Vector{UnitRange{Int}}}
-                            )::Vector{Int}
-    res = Vector{Int}(undef, length(partition))
-    for (i, block) in enumerate(partition)
-        res[i] = length(block)
-    end
-    return res
-end
-
-"""
-This is a temporary decomposition function that only applies a projection and
-keeps the sets lazy.
-Eventually this should be handled in LazySets.
-"""
-function decompose_helper(S::LazySet{N}, blocks::AbstractVector{Int},
-                          n::Int=dim(S)) where {N}
-    result = Vector{LazySet{N}}(undef, length(blocks))
-    block_start = 1
-    @inbounds for (i, bi) in enumerate(blocks)
-        M = sparse(1:bi, block_start:(block_start + bi - 1), ones(N, bi), bi, n)
-        result[i] = M * S
-        block_start += bi
-    end
-    return CartesianProductArray(result)
-end
 
 # sparse/dense matrix conversion
 function matrix_conversion(Δ, options; A_passed=nothing)

--- a/test/Reachability/solve_continuous.jl
+++ b/test/Reachability/solve_continuous.jl
@@ -65,8 +65,7 @@ s = solve(IVP(LCS(A), X0),
 # template directions (eg. :box, :oct, :octbox)
 s = solve(IVP(LCS(A), X0),
           Options(:T=>0.1, :ε_proj=>1e-5, :set_type_proj=>HPolygon),
-          op=BFFPSV18(:vars=>[1,3], :partition=>[1:4],
-                      :template_directions => :oct))
+          op=BFFPSV18(:vars=>[1,3], :partition=>[1:4], :block_options => :oct))
 
 s = solve(IVP(LCS(A), X0),
           Options(:T=>0.1),
@@ -92,16 +91,15 @@ s = solve(IVP(LCS(sparse(A)), X0),
           Options(:T=>0.1),
           op=BFFPSV18(:vars=>[1,3], :partition=>[[i] for i in 1:4],
                       :exp_method=>"lazy",
-                      :set_type=>Interval))
+                      :block_options=>Interval))
 
 # ===============================
 # System with an odd dimension
 # ===============================
 A = randn(5, 5); X0 = BallInf(ones(5), 0.1)
 s = solve(IVP(LCS(sparse(A)), X0), Options(:T=>0.1),
-    op=BFFPSV18(:vars=>[1,3], :partition=>[1:2, 3:4, [5]], :block_types=>
-                Dict{Type{<:LazySet}, AbstractVector{<:AbstractVector{Int}}}(
-                    HPolygon=>[1:2, 3:4], Interval=>[[5]])))
+    op=BFFPSV18(:vars=>[1,3], :partition=>[1:2, 3:4, [5]], :block_options=>
+                [HPolygon, HPolygon, Interval]))
 
 # ===============================
 # System with an odd dimension


### PR DESCRIPTION
Closes #471.

* [x] unify options
* [x] set/check default values
* [x] refactor decomposition
* [x] refactor `overapproximate` (we should add https://github.com/JuliaReach/LazySets.jl/issues/1196 first to make life easier)