### PR TITLE
Fix empty error message in projection

### DIFF
--- a/src/ReachSets/project_reach.jl
+++ b/src/ReachSets/project_reach.jl
@@ -36,7 +36,7 @@ function project_reach(
     else
         got_time = false
         if (xaxis <= 0 || xaxis > n)
-            throw(DomainError())
+            throw(DomainError("value $xaxis for X variable not allowed"))
         end
     end
 
@@ -48,7 +48,7 @@ function project_reach(
         # projection to a state variable
         yaxis = vars[2]
         if (yaxis <= 0 || yaxis > n)
-            throw(DomainError())
+            throw(DomainError("value $yaxis for Y variable not allowed"))
         end
         projection_matrix = sparse([1, 2], [xaxis, yaxis], [1.0, 1.0], 2, m)
     else


### PR DESCRIPTION
Fixes:
```julia
ERROR: LoadError: MethodError: no method matching DomainError()
Closest candidates are:
  DomainError(::Any) at boot.jl:256
  DomainError(::Any, ::Any) at boot.jl:257
```