### PR TITLE
Use inout_map in solve for BFFPSV

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -115,7 +115,7 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
     options = init!(opD, HS, options_input)
     time_horizon = options[:T]
     max_jumps = options[:max_jumps]
-    if opC == BFFPSV18
+    if opC isa BFFPSV18
         inout_map = nothing
     end
     property = options[:mode] == "check" ? options[:property] : nothing
@@ -164,7 +164,7 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
         end
         reach_tube = solve!(IVP(loc, X0.X), options_copy, op=opC)
 
-        if opC == BFFPSV18
+        if opC isa BFFPSV18
              inout_map = reach_tube.options[:inout_map]  # TODO temporary hack
         end
 
@@ -210,7 +210,7 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
     end
 
     # Projection
-    if opC == BFFPSV18
+    if opC isa BFFPSV18
         options[:inout_map] = inout_map
     end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -115,7 +115,9 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
     options = init!(opD, HS, options_input)
     time_horizon = options[:T]
     max_jumps = options[:max_jumps]
-    inout_map = nothing
+    if opC == BFFPSV18
+        inout_map = nothing
+    end
     property = options[:mode] == "check" ? options[:property] : nothing
 
     # waiting_list entries:
@@ -161,7 +163,11 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
             options_copy[:mode] = "reach"
         end
         reach_tube = solve!(IVP(loc, X0.X), options_copy, op=opC)
-        inout_map = reach_tube.options[:inout_map]  # TODO temporary hack
+
+        if opC == BFFPSV18
+             inout_map = reach_tube.options[:inout_map]  # TODO temporary hack
+        end
+
         # get the property for the current location
         property_loc = property isa Dict ?
                        get(property, loc_id, nothing) :
@@ -204,7 +210,10 @@ function solve!(system::InitialValueProblem{<:HybridSystem,
     end
 
     # Projection
-    options[:inout_map] = inout_map
+    if opC == BFFPSV18
+        options[:inout_map] = inout_map
+    end
+
     if options[:project_reachset] || options[:projection_matrix] != nothing
         info("Projection...")
         RsetsProj = @timing project(Rsets, options)


### PR DESCRIPTION
For the purpose of running continuous post different than BFFPSV18, this just ensures that `inout_map` is used for the algorithm that needs it. 