### PR TITLE
#562 - Revise overapproximation options with template directions

### DIFF
--- a/src/ReachSets/DiscretePost/DiscretePost.jl
+++ b/src/ReachSets/DiscretePost/DiscretePost.jl
@@ -60,19 +60,19 @@ function cluster(𝒫::DiscretePost,
                  reach_sets::Vector{ReachSet{LazySet{N}, N}},
                  options::Options) where N<:Real
     clustering_strategy = options[:clustering]
-    dirs = 𝒫.options[:overapproximation]
+    oa = 𝒫.options[:overapproximation]
     if clustering_strategy == :none
         # no clustering, keeping original set
         return reach_sets
     elseif clustering_strategy == :none_oa
         # no clustering but overapproximation
-        return [ReachSet{LazySet{N}, N}(overapproximate(reach_set.X, dirs),
+        return [ReachSet{LazySet{N}, N}(overapproximate(reach_set.X, oa),
                 reach_set.t_start, reach_set.t_end) for reach_set in reach_sets]
     elseif clustering_strategy == :chull
         # cluster all sets in a convex hull and overapproximate that set
         chull = ConvexHullArray(
             LazySet{N}[reach_set.X for reach_set in reach_sets])
-        chull_oa = overapproximate(chull, dirs)
+        chull_oa = overapproximate(chull, oa)
         return [ReachSet{LazySet{N}, N}(chull_oa, reach_sets[1].t_start,
                 reach_sets[end].t_end)]
     end
@@ -102,22 +102,6 @@ end
 function use_precise_ρ(𝒫::DiscretePost,
                              cap::Intersection{N})::Bool where N<:Real
     return true
-end
-
-function get_overapproximation_option(𝒫::DiscretePost, n::Int)
-    oa = 𝒫.options[:overapproximation]
-    if oa isa Symbol
-        dirs = Utils.template_direction_symbols[oa]
-        return dirs(n)
-    elseif oa isa Type{<:LazySets.LazySet}
-        return oa
-    elseif oa isa LazySets.Approximations.AbstractDirections
-        return oa
-    elseif oa <: LazySets.Approximations.AbstractDirections
-        return oa
-    else
-        error("received unknown :overapproximation option $oa")
-    end
 end
 
 # --- default methods for handling assignments ---

--- a/src/ReachSets/DiscretePost/LazyDiscretePost.jl
+++ b/src/ReachSets/DiscretePost/LazyDiscretePost.jl
@@ -88,7 +88,6 @@ function tube⋂inv!(𝒫::LazyDiscretePost,
                    start_interval
                   ) where {N}
 
-    # TODO dirs = get_overapproximation_option(op, dim(invariant)) ?
     dirs = 𝒫.options[:overapproximation]
 
     # counts the number of sets R⋂I added to Rsets
@@ -121,8 +120,7 @@ function post(𝒫::LazyDiscretePost,
               options
              ) where {N}
     jumps += 1
-    # TODO? oa = 𝒫.options[:overapproximation]
-    oa = get_overapproximation_option(𝒫, options[:n])
+    oa = 𝒫.options[:overapproximation]
     source_invariant = HS.modes[source_loc_id].X
     inv_isa_Hrep, inv_isa_H_polytope = get_Hrep_info(source_invariant)
 

--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -383,12 +383,6 @@ function convert_partition(partition::AbstractVector{<:AbstractVector{Int}})::Un
     return partition_out
 end
 
-template_direction_symbols = Dict(
-    :box     => Approximations.BoxDirections,
-    :oct     => Approximations.OctDirections,
-    :boxdiag => Approximations.BoxDiagDirections
-    )
-
 # sparse/dense matrix conversion
 function matrix_conversion(Δ, options; A_passed=nothing)
     if A_passed == nothing

--- a/test/Reachability/solve_continuous.jl
+++ b/test/Reachability/solve_continuous.jl
@@ -72,10 +72,11 @@ s = solve(IVP(LCS(A), X0),
 # Test reachability options
 # ===============================
 
-# template directions (eg. :box, :oct, :octbox)
+# template directions
 s = solve(IVP(LCS(A), X0),
           Options(:T=>0.1, :ε_proj=>1e-5, :set_type_proj=>HPolygon),
-          op=BFFPSV18(:vars=>[1,3], :partition=>[1:4], :block_options => :oct))
+          op=BFFPSV18(:vars=>[1,3], :partition=>[1:4],
+                      :block_options => LazySets.Approximations.OctDirections))
 
 s = solve(IVP(LCS(A), X0),
           Options(:T=>0.1),


### PR DESCRIPTION
Closes #562.
Closes #628.

I decided to remove the overapproximation symbols because they complicate things considerably. We anyway never truly used them.