### PR TITLE
#632 - Namespace conflict with TaylorSeries.update!

### DIFF
--- a/src/ReachSets/ContinuousPost/BFFPS19/reach.jl
+++ b/src/ReachSets/ContinuousPost/BFFPS19/reach.jl
@@ -4,7 +4,6 @@ using LazySets: CacheMinkowskiSum,
                  isdisjoint
 
 import LazySets.Approximations: overapproximate
-import ProgressMeter: update!
 
 """
 combine_cpas(cpa1::CartesianProductArray{N, S}, cpa2::CartesianProductArray{N, S},

--- a/src/ReachSets/ContinuousPost/BFFPS19/reach_blocks.jl
+++ b/src/ReachSets/ContinuousPost/BFFPS19/reach_blocks.jl
@@ -80,7 +80,7 @@ function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
                        progress_meter::Union{Progress, Nothing},
                        res::Vector{<:ReachSet}
                        )::Tuple{Int, Bool} where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     array = CartesianProductArray(Xhat0[blocks])
     X_store = (output_function == nothing) ?
         array :
@@ -126,7 +126,7 @@ function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
 
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         X_store = deco_post_sparse(b, blocks, Whatk_blocks, partition,
                                           ϕpowerk, Xhatk, Xhat0, output_function, overapproximate)
 
@@ -189,7 +189,7 @@ function reach_blocks!(ϕ::AbstractMatrix{NUM},
                        progress_meter::Union{Progress, Nothing},
                        res::Vector{<:ReachSet}
                        )::Tuple{Int, Bool} where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     array = CartesianProductArray(Xhat0[blocks])
     X_store = (output_function == nothing) ?
         array :
@@ -237,7 +237,7 @@ function reach_blocks!(ϕ::AbstractMatrix{NUM},
     arr = Vector{LazySet{NUM}}(undef, arr_length)
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         X_store = deco_post_dense(b, blocks, Whatk_blocks, partition, ϕpowerk,
                     arr, arr_length, U, Xhat0, Xhatk, output_function, overapproximate)
         t0 = t1

--- a/src/ReachSets/ContinuousPost/BFFPSV18/check_blocks.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18/check_blocks.jl
@@ -36,7 +36,7 @@ function check_blocks(ϕ::SparseMatrixCSC{NUM, Int},
                        prop::Property,
                        progress_meter::Union{Progress, Nothing}
                        )::Int where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     violation_index = 0
     if !check(prop, CartesianProductArray(Xhat0[blocks]))
         if eager_checking
@@ -62,7 +62,7 @@ function check_blocks(ϕ::SparseMatrixCSC{NUM, Int},
 
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         for i in 1:b
             bi = partition[blocks[i]]
             Xhatk_bi = ZeroSet(length(bi))
@@ -114,7 +114,7 @@ function check_blocks(ϕ::AbstractMatrix{NUM},
                        prop::Property,
                        progress_meter::Union{Progress, Nothing}
                        )::Int where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     violation_index = 0
     if !check(prop, CartesianProductArray(Xhat0[blocks]))
         if eager_checking
@@ -142,7 +142,7 @@ function check_blocks(ϕ::AbstractMatrix{NUM},
     arr_length = (U == nothing) ? length(partition) : length(partition) + 1
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         for i in 1:b
             bi = partition[blocks[i]]
             arr = Vector{LazySet{NUM}}(undef, arr_length)
@@ -196,7 +196,7 @@ function check_blocks(ϕ::SparseMatrixExp{NUM},
                        prop::Property,
                        progress_meter::Union{Progress, Nothing}
                        )::Int where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     violation_index = 0
     if !check(prop, CartesianProductArray(Xhat0[blocks]))
         if eager_checking
@@ -222,7 +222,7 @@ function check_blocks(ϕ::SparseMatrixExp{NUM},
 
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         for i in 1:b
             bi = partition[blocks[i]]
             ϕpowerk_πbi = row(ϕpowerk, bi)
@@ -272,7 +272,7 @@ function check_blocks(ϕ::SparseMatrixExp{NUM},
                        prop::Property,
                        progress_meter::Union{Progress, Nothing}
                        )::Int where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     violation_index = 0
     if !check(prop, CartesianProductArray(Xhat0[blocks]))
         if eager_checking
@@ -299,7 +299,7 @@ function check_blocks(ϕ::SparseMatrixExp{NUM},
     arr_length = (U == nothing) ? length(partition) : length(partition) + 1
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         for i in 1:b
             bi = partition[blocks[i]]
             arr = Vector{LazySet{NUM}}(undef, arr_length)

--- a/src/ReachSets/ContinuousPost/BFFPSV18/reach.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18/reach.jl
@@ -4,7 +4,6 @@ using LazySets: CacheMinkowskiSum,
                  isdisjoint
 
 import LazySets.Approximations: overapproximate
-import ProgressMeter: update!
 
 """
     reach(problem, options)
@@ -291,6 +290,3 @@ end
 function has_constant_directions(block_options, i::Int)
     return true
 end
-
-# no-op progress meter for unbounded time
-function update!(::Nothing, ::Int) end

--- a/src/ReachSets/ContinuousPost/BFFPSV18/reach_blocks.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18/reach_blocks.jl
@@ -57,7 +57,7 @@ function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
                        progress_meter::Union{Progress, Nothing},
                        res::Vector{<:ReachSet}
                        )::Tuple{Int, Bool} where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     array = CartesianProductArray(Xhat0[blocks])
     X_store = (output_function == nothing) ?
         array :
@@ -85,7 +85,7 @@ function reach_blocks!(ϕ::SparseMatrixCSC{NUM, Int},
 
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         for i in 1:b
             bi = partition[blocks[i]]
             Xhatk_bi = ZeroSet(length(bi))
@@ -144,7 +144,7 @@ function reach_blocks!(ϕ::AbstractMatrix{NUM},
                        progress_meter::Union{Progress, Nothing},
                        res::Vector{<:ReachSet}
                        )::Tuple{Int, Bool} where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     array = CartesianProductArray(Xhat0[blocks])
     X_store = (output_function == nothing) ?
         array :
@@ -175,7 +175,7 @@ function reach_blocks!(ϕ::AbstractMatrix{NUM},
     arr = Vector{LazySet{NUM}}(undef, arr_length)
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         for i in 1:b
             bi = partition[blocks[i]]
             for (j, bj) in enumerate(partition)
@@ -236,7 +236,7 @@ function reach_blocks!(ϕ::SparseMatrixExp{NUM},
                        progress_meter::Union{Progress, Nothing},
                        res::Vector{<:ReachSet}
                        )::Tuple{Int, Bool} where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     array = CartesianProductArray(Xhat0[blocks])
     X_store = (output_function == nothing) ?
         array :
@@ -264,7 +264,7 @@ function reach_blocks!(ϕ::SparseMatrixExp{NUM},
 
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         for i in 1:b
             bi = partition[blocks[i]]
             ϕpowerk_πbi = row(ϕpowerk, bi)
@@ -322,7 +322,7 @@ function reach_blocks!(ϕ::SparseMatrixExp{NUM},
                        progress_meter::Union{Progress, Nothing},
                        res::Vector{<:ReachSet}
                        )::Tuple{Int, Bool} where {NUM}
-    update!(progress_meter, 1)
+    ProgressMeter.update!(progress_meter, 1)
     array = CartesianProductArray(Xhat0[blocks])
     X_store = (output_function == nothing) ?
         array :
@@ -352,7 +352,7 @@ function reach_blocks!(ϕ::SparseMatrixExp{NUM},
     arr = Vector{LazySet{NUM}}(undef, arr_length)
     k = 2
     @inbounds while true
-        update!(progress_meter, k)
+        ProgressMeter.update!(progress_meter, k)
         for i in 1:b
             bi = partition[blocks[i]]
             ϕpowerk_πbi = row(ϕpowerk, bi)

--- a/src/ReachSets/ContinuousPost/BFFPSV18/reach_blocks_wrapping_effect.jl
+++ b/src/ReachSets/ContinuousPost/BFFPSV18/reach_blocks_wrapping_effect.jl
@@ -40,7 +40,7 @@ function reach_blocks_wrapping_effect!(
     k = 2
     p = Progress(N, 1, "Computing successors ")
     @inbounds while true
-        update!(p, k)
+        ProgressMeter.update!(p, k)
         for i in 1:b
             bi = partition[blocks[i]]
             for (j, bj) in enumerate(partition)

--- a/src/ReachSets/ContinuousPost/TMJets/reach.jl
+++ b/src/ReachSets/ContinuousPost/TMJets/reach.jl
@@ -17,10 +17,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =#
 
+import IntervalArithmetic
 using TaylorSeries
 using TaylorIntegration: jetcoeffs!
 using TaylorModels: validated_step!, TaylorModel1, TaylorModelN
-import IntervalArithmetic
 
 function validated_integ(f!, qq0::AbstractVector{T}, δq0::IntervalBox{N,T},
         t0::T, tmax::T, orderQ::Int, orderT::Int, abstol::T;

--- a/src/ReachSets/ReachSets.jl
+++ b/src/ReachSets/ReachSets.jl
@@ -6,7 +6,12 @@ module ReachSets
 
 using ..Utils, ..Properties
 using LazySets, MathematicalSystems, HybridSystems, Expokit, Optim,
-      LinearAlgebra, SparseArrays, ProgressMeter
+      LinearAlgebra, SparseArrays
+
+import ProgressMeter
+using ProgressMeter: Progress
+# no-op progress meter for unbounded time
+function ProgressMeter.update!(::Nothing, ::Int) end
 
 # fix namespace conflicts with MathematicalSystems
 using LazySets: LinearMap, AffineMap, ResetMap


### PR DESCRIPTION
Closes #632.

The problem here was that both `ProgressMeter` and `TaylorSeries` export `update!`, so we had to use `import` instead of `using` for one of those packages.

Since we use `ProgressMeter.update!` but not `TaylorSeries.update!`, I thought that we should use `import TaylorSeries` and explicitly add the functions from `TaylorSeries` that we use.
While trying this, I discovered an issue with `Requires` which I want to share here.

`TaylorSeries` also exports `normalize_taylor`, but that function only becomes visible after loading `IntervalArithmetic` via `Requires`. This can be seen as follows:
```julia
julia> using TaylorSeries

julia> normalize_taylor
ERROR: UndefVarError: normalize_taylor not defined

julia> import IntervalArithmetic
        
julia> normalize_taylor
normalize_taylor (generic function with 4 methods)
```
So I tried the following in `Reachability`:
```julia
julia> import IntervalArithmetic, TaylorSeries

julia> using TaylorSeries: normalize_taylor, ...
```
While this works perfectly in the REPL, loading this from within a module crashes in the precompilation. The reason is that `Requires` defers the loading to a queue and processes that queue only *after the current command*. Since "the current command" here is "*precompile the module*", the precompilation must finish before the extra code is loaded. And this means that `TaylorSeries.normalize_taylor` is not visible at that time. (This can be tested by adding a print output to the `@require` command in `TaylorSeries`.)

So I ended up with `import ProgressMeter` and writing `ProgressMeter.update!` everywhere. Note that ultimately there is no way around this and `using MyPackage` is only a convenience functionality to avoid spelling out the package in most cases.