### PR TITLE
Add missing import

### DIFF
--- a/src/Utils/Utils.jl
+++ b/src/Utils/Utils.jl
@@ -4,7 +4,7 @@ decompositions and visualization.
 """
 module Utils
 
-using LazySets, MathematicalSystems, HybridSystems, Printf
+using LazySets, MathematicalSystems, HybridSystems, SparseArrays, Printf
 
 # fix namespace conflicts with MathematicalSystems
 using LazySets: LinearMap, AffineMap, ResetMap


### PR DESCRIPTION
`sparse` is used in function `matrix_conversion`.