### PR TITLE
Fix crashes in Schur transformation

### DIFF
--- a/src/Utils/transformations.jl
+++ b/src/Utils/transformations.jl
@@ -1,6 +1,33 @@
 using LinearAlgebra
 
-export transform
+export transform,
+       backtransform
+
+"""
+    backtransform(Rsets::ReachSolution, options::Options)
+
+Undo a coordinate transformation.
+
+### Input
+
+- `Rsets`  -- flowpipe
+- `option` -- problem options containing an `:transformation_matrix` entry
+
+### Output
+
+A new flowpipe where each reach set has been transformed.
+
+### Notes
+
+The transformation is implemented with a lazy `LinearMap`.
+"""
+function backtransform(Rsets, options::Options)
+    transformation_matrix = options[:transformation_matrix]
+    if transformation_matrix == nothing
+        return Rsets
+    end
+    return project(Rsets, transformation_matrix)
+end
 
 """
     transform(problem::InitialValueProblem, options::Options)

--- a/src/Utils/transformations.jl
+++ b/src/Utils/transformations.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra
+
 export transform
 
 """
@@ -25,8 +27,8 @@ function transform(problem::InitialValueProblem, options::Options)
     if method == ""
         nothing # no-op
     elseif method == "schur"
-        options[:transformation_matrix] = Tm
-        problem = schur_transform(problem)
+        problem, T_inverse = schur_transform(problem)
+        options[:transformation_matrix] = T_inverse
     else
         error("the transformation method $method is undefined")
     end
@@ -40,7 +42,7 @@ Applies a Schur transformation to a discrete or continuous initial-value problem
 
 ### Input
 
-- `S` -- discrete or continuous initial-value problem
+- `problem` -- discrete or continuous initial-value problem
 
 ### Output
 
@@ -58,19 +60,26 @@ function schur_transform(problem::InitialValueProblem{PT, ST}
     n = size(problem.s.A, 1)
 
     # full (dense) matrix is required by schur
-    A_new, T_new = schur(Matrix(problem.s.A))
+    # result S is a struct such that
+    # - S.Schur is in Schur form and
+    # - A == S.vectors * S.Schur * S.vectors'
+    S = schur(Matrix(problem.s.A))
 
     # recall that for Schur matrices, inv(T) == T'
-    Z_inverse = copy(transpose(T_new))
+    Z_inverse = copy(transpose(S.vectors))
+
+    # obtain transformed system matrix
+    A_new = S.Schur
 
     # apply transformation to the initial states
     X0_new = Z_inverse * problem.x0
 
     # apply transformation to the inputs
-    U_new = Z_inverse * problem.s.U
+    B_new = Z_inverse * problem.s.B
+    U_new = problem.s.U
 
-    # obtain the transformation matrix for reverting the transformation again
-    T_inverse = F[:vectors]
+    # matrix for reverting the transformation again
+    T_inverse = S.vectors
 
     # apply transformation to the invariant
     if hasmethod(stateset, Tuple{typeof(problem.s)})
@@ -79,6 +88,17 @@ function schur_transform(problem::InitialValueProblem{PT, ST}
         invariant_new = Universe(n)
     end
 
-    system_new = (A_new, I(n), invariant_new, U_new)
-    return InitialValueProblem(PT(system_new), X0_new)
+    system_new = _wrap_system(PT, A_new, B_new, invariant_new, U_new)
+    problem_new = InitialValueProblem(system_new, X0_new)
+    return problem_new, T_inverse
+end
+
+function _wrap_system(PT::Type{<:ConstrainedLinearControlDiscreteSystem},
+                      A, B, invariant, U)
+    return ConstrainedLinearControlDiscreteSystem(A, B, invariant, U)
+end
+
+function _wrap_system(PT::Type{<:ConstrainedLinearControlContinuousSystem},
+                      A, B, invariant, U)
+    return ConstrainedLinearControlContinuousSystem(A, B, invariant, U)
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -71,7 +71,10 @@ function solve!(problem::InitialValueProblem,
     problem, options = transform(problem, options)
 
     # run the continuous-post operator
-    post(op, problem, options)
+    res = post(op, problem, options)
+
+    # undo a coordinate transformation
+    res = backtransform(res, options)
 end
 
 """


### PR DESCRIPTION
My test below shows that there is still something missing to back-transform the result. But I think this PR still improves the state by not crashing anymore.

```julia
using SparseArrays, MathematicalSystems, Reachability

A = sparse([1, 1, 2, 2], [1, 2, 1, 2], [3., -9., 4., -3.])
B = reshape([0.0, -1.0], (2, 1))
U = Singleton([1.0])
inv = Universe(2)
model = ConstrainedLinearControlContinuousSystem(A, B, inv, ConstantInput(U))
X0 = Hyperrectangle(low=[10.0, 0.0], high=[10.2, 0.0])
problem = InitialValueProblem(model, X0)

𝑂_original = Options(:T => 20.0, :mode => "reach")
𝑂_op_original = Options(:vars => [1, 2], :partition => [[1], [2]], :δ => 0.003)
sol_original = solve(problem, 𝑂_original, op=BFFPSV18(𝑂_op_original))

𝑂_transform = merge(𝑂_original, Options(:coordinate_transformation => "schur"))
𝑂_op_transform = merge(𝑂_op_original, Options())
sol_transform = solve(problem, 𝑂_transform, op=BFFPSV18(𝑂_op_transform))


using Plots
plot(sol_original)
plot(sol_transform)
```
![original](https://user-images.githubusercontent.com/9656686/66145423-1a31a280-e60b-11e9-88d9-8a16cb5bf251.png)
![transform](https://user-images.githubusercontent.com/9656686/66145427-1d2c9300-e60b-11e9-90bc-fbdcfc1d8ee3.png)

EDIT: side note: There is something very wrong with our axis labels :smile: