### PR TITLE
Fix undefined projection_matrix variable

### DIFF
--- a/src/ReachSets/project_reach.jl
+++ b/src/ReachSets/project_reach.jl
@@ -57,16 +57,16 @@ function project_reach(
                     sparse([1, 2], [xaxis, yaxis], [1.0, 1.0], 2, n)
             end
         else
-            @assert size(projection_matrix, 1) == 1 "currently we only " *
-                "support one-dimensional projection matrices"
+            @assert size(projection_matrix_high_dimensional, 1) == 1 "currently " *
+                "we only support one-dimensional projection matrices"
             if got_time
                 # create a 1-row matrix
                 projection_matrix =
-                    sparse(fill(1, n), 1:n, projection_matrix[1, :], 1, n)
+                    sparse(fill(1, n), 1:n, projection_matrix_high_dimensional[1, :], 1, n)
             else
                 # create a 2-row matrix
                 projection_matrix =
-                    sparse(fill(2, n), 1:n, projection_matrix[1, :], 2, n)
+                    sparse(fill(2, n), 1:n, projection_matrix_high_dimensional[1, :], 2, n)
                 projection_matrix[1, xaxis] = 1.0
             end
         end


### PR DESCRIPTION
This fixes the first error in #707. It still crashes at a later problem.

Example from [the notebook](https://github.com/mforets/escritoire/blob/master/reachability/Projection_Errors.ipynb):

```julia
A = rand(4, 4)
S = LinearContinuousSystem(A)
X0 = rand(Hyperrectangle, dim=4)
M = rand(1, 4)  # note that this must matrix be 1D
P = InitialValueProblem(S, X0)
opts = Options(:T=>1.0, :project_reachset=>true, :projection_matrix=>M)
opts_algo = Options(:δ=>0.1, :vars=>[1, 2])
solve(P, opts, op=BFFPSV18(opts_algo))
```