### PR TITLE
Fix ABS07_decomposed with inputs

### DIFF
--- a/src/ReachSets/ContinuousPost/ASB07_decomposed/reach.jl
+++ b/src/ReachSets/ContinuousPost/ASB07_decomposed/reach.jl
@@ -50,6 +50,15 @@ function reach_ASB07_decomposed!(R::Vector{<:ReachSet},
         t1 += δ
         R[k] = ReachSet(Rₖ, t0, t1)
 
+        if U != nothing
+            for i in 1:b
+                bi = partition[blocks[i]]
+                block_row = IntervalMatrix(row(ϕpowerk, bi))
+                W_new = overapproximate(block_row * inputs, Zonotope)
+                Whatk[i] = minkowski_sum(Whatk[i], W_new)
+            end
+        end
+
         ϕpowerk *= ϕ
 
         k += 1


### PR DESCRIPTION
This fixes a bug in `ABS07_decomposed` where the inputs were not multiplied with the matrix power.