### PR TITLE
Remove order reduction in GLGM06

### DIFF
--- a/src/ReachSets/ContinuousPost/GLGM06/post.jl
+++ b/src/ReachSets/ContinuousPost/GLGM06/post.jl
@@ -17,6 +17,7 @@ function post(𝒜::GLGM06,
                                   exp_method=𝑂[:exp_method],
                                   set_operations="zonotope")
     Ω0, Φ = 𝑃_discrete.x0, 𝑃_discrete.s.A
+    Ω0red = reduce_order(Ω0, max_order)
 
     # =====================
     # Flowpipe computation
@@ -28,11 +29,11 @@ function post(𝒜::GLGM06,
     info("Reachable States Computation...")
     @timing begin
     if inputdim(𝑃_discrete) == 0
-        reach_homog!(Rsets, Ω0, Φ, N, δ, max_order)
+        reach_homog!(Rsets, Ω0red, Φ, N, δ)
 
     else
         U = inputset(𝑃_discrete)
-        reach_inhomog!(Rsets, Ω0, U, Φ, N, δ, max_order)
+        reach_inhomog!(Rsets, Ω0red, U, Φ, N, δ, max_order)
     end
     end # timing
 

--- a/src/ReachSets/ContinuousPost/GLGM06/reach.jl
+++ b/src/ReachSets/ContinuousPost/GLGM06/reach.jl
@@ -6,12 +6,10 @@ function reach_homog!(R::Vector{ReachSet{<:Zonotope{Float64}}},
                       Ω0::Zonotope,
                       Φ::AbstractMatrix,
                       N::Int,
-                      δ::Float64,
-                      max_order::Int)
+                      δ::Float64)
     # initial reach set
     t0, t1 = zero(δ), δ
-    Ω0red = reduce_order(Ω0, max_order)
-    R[1] = ReachSet(Ω0red, t0, t1)
+    R[1] = ReachSet(Ω0, t0, t1)
 
     k = 2
     while k <= N


### PR DESCRIPTION
Originally this PR should just remove the order reduction in a homogeneous `GLGM06` run.

~But then I hit a wall that the new `LazySets` v1.32 is incompatible with our flowpipes consisting of sets of fixed type (because the type may change during the analysis).~

~This PR adds a brute-force conversion for `GLGM06` but some work would be needed for other algorithms as well.~
~(The conversion after order reduction might be redundant.)~