### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,15 @@ matrix:
   allow_failures:
     - julia: 1.3  # development versions
       env: TEST_SUITE='using Pkg; Pkg.develop("LazySets"); Pkg.develop("MathematicalSystems"); Pkg.develop("HybridSystems"); Pkg.develop("MathematicalPredicates"); Pkg.develop("TaylorModels"); Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
-  #include:
+  include:
     - julia: 1.0
+      env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
+    - julia: 1.2
       env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
     - julia: 1.3
       env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=true
+    #- julia: 1.4
+    #  env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
 
 script:
   - julia -e "$TEST_SUITE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,10 @@ matrix:
     - julia: 1.3  # development versions
       env: TEST_SUITE='using Pkg; Pkg.develop("LazySets"); Pkg.develop("MathematicalSystems"); Pkg.develop("HybridSystems"); Pkg.develop("MathematicalPredicates"); Pkg.develop("TaylorModels"); Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
   #include:
-    #- julia: 1.0 
-    #  env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
-    #- julia: 1.1 
-    #  env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
+    - julia: 1.0
+      env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
     - julia: 1.3
       env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=true
-    #- julia: 1.2  # development versions
-    #  env: TEST_SUITE='using Pkg; Pkg.develop("LazySets"); Pkg.develop("MathematicalSystems"); Pkg.develop("HybridSystems"); Pkg.develop("MathematicalPredicates"); Pkg.develop("TaylorModels"); Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
 
 script:
   - julia -e "$TEST_SUITE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,17 @@ git:
 matrix:
   fast_finish: true
   allow_failures:
-    - julia: 1.2  # development versions
+    - julia: 1.4  # development versions
       env: TEST_SUITE='using Pkg; Pkg.develop("LazySets"); Pkg.develop("MathematicalSystems"); Pkg.develop("HybridSystems"); Pkg.develop("MathematicalPredicates"); Pkg.develop("TaylorModels"); Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
-  include:
-    - julia: 1.0  # master versions
-      env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
-    - julia: 1.1  # master versions
-      env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
-    - julia: 1.2  # master versions
+  #include:
+    #- julia: 1.0 
+    #  env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
+    #- julia: 1.1 
+    #  env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
+    - julia: 1.4 
       env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=true
-    - julia: 1.2  # development versions
-      env: TEST_SUITE='using Pkg; Pkg.develop("LazySets"); Pkg.develop("MathematicalSystems"); Pkg.develop("HybridSystems"); Pkg.develop("MathematicalPredicates"); Pkg.develop("TaylorModels"); Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
+    #- julia: 1.2  # development versions
+    #  env: TEST_SUITE='using Pkg; Pkg.develop("LazySets"); Pkg.develop("MathematicalSystems"); Pkg.develop("HybridSystems"); Pkg.develop("MathematicalPredicates"); Pkg.develop("TaylorModels"); Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
 
 script:
   - julia -e "$TEST_SUITE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ git:
 matrix:
   fast_finish: true
   allow_failures:
-    - julia: 1.4  # development versions
+    - julia: 1.3  # development versions
       env: TEST_SUITE='using Pkg; Pkg.develop("LazySets"); Pkg.develop("MathematicalSystems"); Pkg.develop("HybridSystems"); Pkg.develop("MathematicalPredicates"); Pkg.develop("TaylorModels"); Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
   #include:
     #- julia: 1.0 
     #  env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
     #- julia: 1.1 
     #  env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
-    - julia: 1.4 
+    - julia: 1.3
       env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=true
     #- julia: 1.2  # development versions
     #  env: TEST_SUITE='using Pkg; Pkg.develop("LazySets"); Pkg.develop("MathematicalSystems"); Pkg.develop("HybridSystems"); Pkg.develop("MathematicalPredicates"); Pkg.develop("TaylorModels"); Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
       env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=true
     #- julia: 1.4
     #  env: TEST_SUITE='using Pkg; Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
+    - julia: 1.3  # development versions
+      env: TEST_SUITE='using Pkg; Pkg.develop("LazySets"); Pkg.develop("MathematicalSystems"); Pkg.develop("HybridSystems"); Pkg.develop("MathematicalPredicates"); Pkg.develop("TaylorModels"); Pkg.build("Reachability"); Pkg.test("Reachability"; coverage=true)'; DOCS=false
 
 script:
   - julia -e "$TEST_SUITE"


### PR DESCRIPTION
In the Project.toml we have LazySets = "1.30, 1.31", but travis.yml requires tests to *pass* with the development version of LazySets. This change adjusts travis.yml with Project.toml.