### PR TITLE
Relax type restriction of Flowpipe

### DIFF
--- a/src/ReachSets/ContinuousPost/GLGM06/post.jl
+++ b/src/ReachSets/ContinuousPost/GLGM06/post.jl
@@ -23,7 +23,7 @@ function post(𝒜::GLGM06,
     # =====================
 
     # preallocate output
-    Rsets = Vector{ReachSet{Zonotope{Float64}}}(undef, N)
+    Rsets = Vector{ReachSet{<:Zonotope{Float64}}}(undef, N)
 
     info("Reachable States Computation...")
     @timing begin

--- a/src/ReachSets/ContinuousPost/GLGM06/reach.jl
+++ b/src/ReachSets/ContinuousPost/GLGM06/reach.jl
@@ -2,7 +2,7 @@
 # Homogeneous case
 # ================
 
-function reach_homog!(R::Vector{ReachSet{Zonotope{Float64}}},
+function reach_homog!(R::Vector{ReachSet{<:Zonotope{Float64}}},
                       Ω0::Zonotope,
                       Φ::AbstractMatrix,
                       N::Int,
@@ -29,7 +29,7 @@ end
 # Inhomogeneous case
 # ==================
 
-function reach_inhomog!(R::Vector{ReachSet{Zonotope{Float64}}},
+function reach_inhomog!(R::Vector{ReachSet{<:Zonotope{Float64}}},
                         Ω0::Zonotope,
                         U::ConstantInput,
                         Φ::AbstractMatrix,

--- a/src/ReachSets/ContinuousPost/TMJets/post.jl
+++ b/src/ReachSets/ContinuousPost/TMJets/post.jl
@@ -13,7 +13,7 @@ const symI = IA.Interval(-1.0, 1.0)
 function _to_hyperrectangle(tTM, xTM, n)
     N = length(xTM)
     SET_TYPE = Hyperrectangle{Float64, SVector{n, Float64}, SVector{n, Float64}}
-    Rsets = Vector{ReachSet{SET_TYPE}}(undef, N-1)
+    Rsets = Vector{ReachSet{<:SET_TYPE}}(undef, N-1)
     @inbounds for i in 1:N-1
         Hi = convert(Hyperrectangle, xTM[i])
         t0 = tTM[i]
@@ -26,7 +26,7 @@ end
 function _to_intervalbox(tTM, xTM, n)
     N = length(xTM)
     SET_TYPE = IA.IntervalBox{n, Float64}
-    Rsets = Vector{ReachSet{SET_TYPE}}(undef, N-1)
+    Rsets = Vector{ReachSet{<:SET_TYPE}}(undef, N-1)
     @inbounds for i in 1:N-1
         Bi = xTM[i]
         t0 = tTM[i]
@@ -39,7 +39,7 @@ end
 function _to_zonotope(tTM, vTM, n)
     N = length(tTM)
     SET_TYPE = Zonotope{Float64}
-    Rsets = Vector{ReachSet{SET_TYPE}}(undef, N-1)
+    Rsets = Vector{ReachSet{<:SET_TYPE}}(undef, N-1)
     @inbounds for i in 1:N-1 # loop over the reach sets
         # pick the i-th Taylor model
         X = vTM[:, i]

--- a/src/ReachSets/Flowpipe.jl
+++ b/src/ReachSets/Flowpipe.jl
@@ -1,5 +1,5 @@
 """
-    Flowpipe{SN, RSN<:AbstractReachSet{SN}} <: AbstractSolution
+    Flowpipe{RSN<:AbstractReachSet} <: AbstractSolution
 
 Wrapper of a sequence of sets (the solution of a continuous-post operator).
 
@@ -7,7 +7,7 @@ Wrapper of a sequence of sets (the solution of a continuous-post operator).
 
 - `reachsets` -- the list of [`AbstractReachSet`](@ref)s
 """
-struct Flowpipe{SN, RSN<:AbstractReachSet{SN}}
+struct Flowpipe{RSN<:AbstractReachSet}
     reachsets::Vector{RSN}
 end
 


### PR DESCRIPTION
This fixes the tests again and also would allow to bump `LazySets`.

Parts of this PR are similar to #751.